### PR TITLE
Don't throw a PHP notice for unknown command (e. g. `cmd-delete`)

### DIFF
--- a/lib/BeanstalkInterface.class.php
+++ b/lib/BeanstalkInterface.class.php
@@ -60,9 +60,13 @@ class BeanstalkInterface
 		
 		foreach ( $this->_client->statsTube( $tube ) as $key => $value )
 		{
-			$stats[] = array( 
-				'key' => $nameTube[ $key ], 
-				'value' => $value, 
+			if (! array_key_exists($key, $nameTube)) {
+				continue;
+			}
+
+			$stats[] = array(
+				'key' => $nameTube[ $key ],
+				'value' => $value,
 				'descr' => isset( $descr[ $key ] ) ? $descr[ $key ] : '' );
 		}
 		return $stats;


### PR DESCRIPTION
The statsTube() method returns stats for `cmd-delete` but this isn't defined in the $nameTube array in BeanstalkInterface.class.php, so a PHP notice is shown. (see http://mj.gs/-7n)

This patch fixes this.
