### PR TITLE
delete last server without cannot connect exception, remove cookie

### DIFF
--- a/lib/tpl/serversList.php
+++ b/lib/tpl/serversList.php
@@ -41,7 +41,7 @@ if (!empty($_COOKIE['filter'])) {
                     <?php if(empty($stats)):?>
                         <td colspan="<?php echo count($visible)?>" class="row-full">&nbsp;</td>
                     <?php endif?>
-                    <td><a class="btn btn-small" title="Remove from list" href="?action=serversRemove&removeServer=<?php echo $server?>&server=<?php echo $server?>"><span class="icon-minus"></span></a></td>
+                    <td><a class="btn btn-small" title="Remove from list" href="?action=serversRemove&removeServer=<?php echo $server?>"><span class="icon-minus"></span></a></td>
                 </tr>
             <?php endforeach?>
         </tbody>


### PR DESCRIPTION
1. when you wanted to remove a server, when it's offline, the current code block, hit the exception and never got to execute serversRemove action. This is fixed now with a separate block of code, that doesn't initiate a connect.
2. when there are no server, for certain browsers is better to remove/delete the cookie.
