### PR TITLE
use getenv function for BEANSTALK_SERVERS

### DIFF
--- a/lib/include.php
+++ b/lib/include.php
@@ -227,8 +227,8 @@ class Console {
         foreach ($config['servers'] as $server) {
             $this->serversConfig[] = $server;
         }
-        if (isset($_ENV['BEANSTALK_SERVERS'])) {
-            foreach (explode(",", $_ENV["BEANSTALK_SERVERS"]) as $server) {
+        if (null !== getenv('BEANSTALK_SERVERS')) {
+            foreach (explode(',', getenv('BEANSTALK_SERVERS')) as $server) {
                 $this->serversEnv[] = $server;
             }
         }


### PR DESCRIPTION
`$_ENV` global has varying support depending on configuration and server
environment - https://stackoverflow.com/questions/3780866/why-is-my-env-empty

I also changed the quotes used to match the rest of the file.