### PR TITLE
set the proper permission bits on storage.json

### DIFF
--- a/src/Storage.php
+++ b/src/Storage.php
@@ -27,7 +27,7 @@ class Storage implements IStorage {
             return false;
         }
         if (!is_writable($this->file)) {
-            @chmod($this->file, '0755');
+            @chmod($this->file, 0755);
             if (!is_writable($this->file)) {
                 $this->error = "Please make the storage file writable: $this->file";
                 return false;


### PR DESCRIPTION
chmod '0755' actually sets the mode to:  --wxrw--wt
chmod needs permissions in octal to set: -rwxr-xr-x

I found this while installing my perl wrapper: https://github.com/karenetheridge/Plack-App-BeanstalkConsole -- because it runs the code (via tests) before installing, so the storage.json that came with the application has its permissions twiddled, and then the perl installer fails to copy that file into its destination directory.

