### PR TITLE
Normalize references to "./index.php?" for embedded proxy compatibility

### DIFF
--- a/lib/include.php
+++ b/lib/include.php
@@ -365,7 +365,7 @@ class Console {
     protected function _actionKick() {
         $this->interface->kick($this->_globalVar['tube'], $this->_globalVar['count']);
         header(
-                sprintf('Location: index.php?server=%s&tube=%s', $this->_globalVar['server'], $this->_globalVar['tube']));
+                sprintf('Location: ./?server=%s&tube=%s', $this->_globalVar['server'], $this->_globalVar['tube']));
         exit();
     }
 
@@ -375,7 +375,7 @@ class Console {
             $this->interface->_client->kickJob($job);
         }
         header(
-                sprintf('Location: index.php?server=%s&tube=%s', $this->_globalVar['server'], $this->_globalVar['tube']));
+                sprintf('Location: ./?server=%s&tube=%s', $this->_globalVar['server'], $this->_globalVar['tube']));
         exit();
     }
 
@@ -411,7 +411,7 @@ class Console {
             $this->_globalVar['tube'] = null;
         }
         header(
-                sprintf('Location: index.php?server=%s&tube=%s', $this->_globalVar['server'], $this->_globalVar['tube']));
+                sprintf('Location: ./?server=%s&tube=%s', $this->_globalVar['server'], $this->_globalVar['tube']));
         exit();
     }
 
@@ -434,7 +434,7 @@ class Console {
             // no servers, clear cookie
             setcookie('beansServers', '', time() - 86400 * 365);
         }
-        header('Location: index.php');
+        header('Location: ./?');
         exit();
     }
 
@@ -485,7 +485,7 @@ class Console {
         }
         $this->interface->pauseTube($this->_globalVar['tube'], $this->_globalVar['count']);
         header(
-                sprintf('Location: index.php?server=%s&tube=%s', $this->_globalVar['server'], $this->_globalVar['tube']));
+                sprintf('Location: ./?server=%s&tube=%s', $this->_globalVar['server'], $this->_globalVar['tube']));
         exit();
     }
 
@@ -530,7 +530,7 @@ class Console {
             $_SESSION['info'] = 'Job placed on tube';
             header(sprintf('Location: %s', $_GET['redirect']));
         } else {
-            header(sprintf('Location: index.php?server=%s&tube=%s', $this->_globalVar['server'], $this->_globalVar['tube']));
+            header(sprintf('Location: ./?server=%s&tube=%s', $this->_globalVar['server'], $this->_globalVar['tube']));
         }
         exit();
     }
@@ -555,7 +555,7 @@ class Console {
                     $job['tubes'] = $_POST['tubes'];
                     $job['data'] = htmlspecialchars_decode($_POST['jobdata']);
                     if ($storage->saveJob($job)) {
-                        header('Location: index.php?action=manageSamples');
+                        header('Location: ./?action=manageSamples');
                     } else {
                         $storage->saveJob($oldjob);
                         $this->_tplVars['error'] = $storage->getError();
@@ -587,7 +587,7 @@ class Console {
                         $serverTubes[$server] = $tubes;
                     }
                 } catch (Exception $e) {
-                    
+
                 }
             }
         }
@@ -609,7 +609,7 @@ class Console {
                 $job['tubes'] = $_POST['tubes'];
                 $job['data'] = htmlspecialchars_decode($_POST['jobdata']);
                 if ($storage->saveJob($job)) {
-                    header('Location: index.php?action=manageSamples');
+                    header('Location: ./?action=manageSamples');
                 } else {
                     $this->_tplVars['error'] = $storage->getError();
                 }
@@ -631,7 +631,7 @@ class Console {
                         $serverTubes[$server] = $tubes;
                     }
                 } catch (Exception $e) {
-                    
+
                 }
             }
         }
@@ -651,7 +651,7 @@ class Console {
                 $storage->delete($key);
             }
         }
-        header('Location: index.php?action=manageSamples');
+        header('Location: ./?action=manageSamples');
         exit();
     }
 
@@ -712,7 +712,7 @@ class Console {
                     break;
             }
         } catch (Exception $e) {
-            
+
         }
 
         if ($job === null)
@@ -730,7 +730,7 @@ class Console {
                     $added++;
                 }
             } catch (Pheanstalk_Exception_ServerException $e) {
-                
+
             }
             if ($added >= $limit || (microtime(true) - $this->actionTimeStart) > $limit) {
                 break;
@@ -786,7 +786,7 @@ class Console {
         } catch (Exception $e) {
             // there might be no jobs to peek at, and peekReady raises exception in this situation
         }
-        header(sprintf('Location: index.php?server=%s&tube=%s', $server, $destTube));
+        header(sprintf('Location: ./?server=%s&tube=%s', $server, $destTube));
     }
 
     private function moveJobsToState($server, $tube, $state, $destState) {
@@ -815,7 +815,7 @@ class Console {
         } catch (Exception $e) {
             // there might be no jobs to peek at, and peekReady raises exception in this situation
         }
-        header(sprintf('Location: index.php?server=%s&tube=%s', $server, $tube));
+        header(sprintf('Location: ./?server=%s&tube=%s', $server, $tube));
     }
 
 }

--- a/lib/tpl/allTubes.php
+++ b/lib/tpl/allTubes.php
@@ -22,7 +22,7 @@ $visible = $console->getTubeStatVisible();
                 <tbody>
                     <?php foreach ((is_array($tubes) ? $tubes : array()) as $tubeItem): ?>
                         <tr>
-                            <td name="<?php echo $key ?>"><a href="index.php?server=<?php echo $server ?>&tube=<?php echo $tubeItem ?>"><?php echo $tubeItem ?></a>
+                            <td name="<?php echo $key ?>"><a href="./?server=<?php echo $server ?>&tube=<?php echo $tubeItem ?>"><?php echo $tubeItem ?></a>
                             </td>
                             <?php $tubeStats = $console->getTubeStatValues($tubeItem) ?>
                             <?php

--- a/lib/tpl/currentTubeJobsActionsRow.php
+++ b/lib/tpl/currentTubeJobsActionsRow.php
@@ -9,16 +9,16 @@ if (!@empty($_COOKIE['tubePauseSeconds'])) {
 ?>
 <section id="actionsRow">
     <b>Actions:</b>&nbsp;
-    <a class="btn btn-default btn-sm" href="?server=<?php echo $server ?>&tube=<?php echo $tube ?>&action=kick&count=1"><i class="glyphicon glyphicon-forward"></i> Kick 1 job</a>
-    <a class="btn btn-default btn-sm" href="?server=<?php echo $server ?>&tube=<?php echo $tube ?>&action=kick&count=10"
+    <a class="btn btn-default btn-sm" href="./?server=<?php echo $server ?>&tube=<?php echo $tube ?>&action=kick&count=1"><i class="glyphicon glyphicon-forward"></i> Kick 1 job</a>
+    <a class="btn btn-default btn-sm" href="./?server=<?php echo $server ?>&tube=<?php echo $tube ?>&action=kick&count=10"
        title="To kick more jobs, edit the `count` parameter"><i class="glyphicon glyphicon-fast-forward"></i> Kick 10 job</a>
        <?php
        if (empty($tubeStats['pause-time-left'])) {
-           ?><a class="btn btn-default btn-sm" href="?server=<?php echo $server ?>&tube=<?php echo $tube ?>&action=pause&count=-1"
+           ?><a class="btn btn-default btn-sm" href="./?server=<?php echo $server ?>&tube=<?php echo $tube ?>&action=pause&count=-1"
            title="Temporarily prevent jobs being reserved from the given tube. Pause for: <?php echo $tubePauseSeconds; ?> seconds"><i class="glyphicon glyphicon-pause"></i>
             Pause tube</a><?php
     } else {
-        ?><a class="btn btn-default btn-sm" href="?server=<?php echo $server ?>&tube=<?php echo $tube ?>&action=pause&count=0"
+        ?><a class="btn btn-default btn-sm" href="./?server=<?php echo $server ?>&tube=<?php echo $tube ?>&action=pause&count=0"
            title="<?php echo sprintf('Pause seconds left: %d', $tubeStats['pause-time-left']); ?>"><i class="glyphicon glyphicon-play"></i> Unpause tube</a><?php
        }
        ?>
@@ -35,13 +35,13 @@ if (!@empty($_COOKIE['tubePauseSeconds'])) {
                 foreach ($sampleJobs as $key => $name) {
                     ?>
                     <li>
-                        <a href="?server=<?php echo $server ?>&tube=<?php echo $tube ?>&action=loadSample&key=<?php echo $key; ?>"><?php echo htmlspecialchars($name); ?></a>
+                        <a href="./?server=<?php echo $server ?>&tube=<?php echo $tube ?>&action=loadSample&key=<?php echo $key; ?>"><?php echo htmlspecialchars($name); ?></a>
                     </li>
                     <?php
                 }
                 ?>
                 <li class="divider"></li>
-                <li><a href="?action=manageSamples">Manage samples</a></li>
+                <li><a href="./?action=manageSamples">Manage samples</a></li>
                 <?php
             } else {
                 ?>

--- a/lib/tpl/currentTubeJobsShowcase.php
+++ b/lib/tpl/currentTubeJobsShowcase.php
@@ -1,5 +1,5 @@
 <section class="jobsShowcase">
-    <?php foreach ($peek as $state => $job): ?>
+    <?php foreach ((array)$peek as $state => $job): ?>
         <hr>
         <div class="pull-left">
             <h3>Next job in "<?php echo $state ?>" state</h3>

--- a/lib/tpl/currentTubeJobsShowcase.php
+++ b/lib/tpl/currentTubeJobsShowcase.php
@@ -35,7 +35,7 @@
                             <div class="pull-right">
                                 <div style="margin-bottom: 3px;">
                                     <a class="btn btn-sm btn-info addSample" data-jobid="<?php echo $job['id']; ?>"
-                                       href="?server=<?php echo $server ?>&tube=<?php echo $tube ?>&action=addSample"><i class="glyphicon glyphicon-plus glyphicon-white"></i> Add to
+                                       href="./?server=<?php echo $server ?>&tube=<?php echo $tube ?>&action=addSample"><i class="glyphicon glyphicon-plus glyphicon-white"></i> Add to
                                         samples</a>
 
                                     <div class="btn-group">
@@ -44,14 +44,14 @@
                                         </button>
                                         <ul class="dropdown-menu">
                                             <li><input class="moveJobsNewTubeName" type="text" class="input-medium"
-                                                       data-href="?server=<?php echo $server ?>&tube=<?php echo $tube ?>&action=moveJobsTo&state=<?php echo $state; ?>&destTube="
+                                                       data-href="./?server=<?php echo $server ?>&tube=<?php echo $tube ?>&action=moveJobsTo&state=<?php echo $state; ?>&destTube="
                                                        placeholder="New tube name"/></li>
                                                 <?php
                                                 if (isset($tubes) && is_array($tubes) && count($tubes)) {
                                                     foreach ($tubes as $key => $name) {
                                                         ?>
                                                     <li>
-                                                        <a href="?server=<?php echo $server ?>&tube=<?php echo $tube ?>&action=moveJobsTo&destTube=<?php echo $name; ?>&state=<?php echo $state; ?>"><?php echo htmlspecialchars($name); ?></a>
+                                                        <a href="./?server=<?php echo $server ?>&tube=<?php echo $tube ?>&action=moveJobsTo&destTube=<?php echo $name; ?>&state=<?php echo $state; ?>"><?php echo htmlspecialchars($name); ?></a>
                                                     </li>
                                                     <?php
                                                 }
@@ -64,7 +64,7 @@
                                                 ?>
                                                 <li class="divider"></li>
                                                 <li>
-                                                    <a href="?server=<?php echo $server ?>&tube=<?php echo $tube ?>&action=moveJobsTo&destState=buried&state=<?php echo $state; ?>">Buried</a>
+                                                    <a href="./?server=<?php echo $server ?>&tube=<?php echo $tube ?>&action=moveJobsTo&destState=buried&state=<?php echo $state; ?>">Buried</a>
                                                 </li>
                                                 <?php
                                             }
@@ -72,11 +72,11 @@
                                         </ul>
                                     </div>
                                     <a class="btn btn-sm btn-danger"
-                                       href="?server=<?php echo $server ?>&tube=<?php echo $tube ?>&state=<?php echo $state ?>&action=deleteAll&count=1"
+                                       href="./?server=<?php echo $server ?>&tube=<?php echo $tube ?>&state=<?php echo $state ?>&action=deleteAll&count=1"
                                        onclick="return confirm('This process might hang a while on tubes with lots of jobs. Are you sure you want to continue?');"><i
                                             class="glyphicon glyphicon-trash glyphicon-white"></i> Delete all <?php echo $state ?> jobs</a>
                                     <a class="btn btn-sm btn-danger"
-                                       href="?server=<?php echo $server ?>&tube=<?php echo $tube ?>&state=<?php echo $state ?>&action=deleteJob&jobid=<?php echo $job['id'];?>"><i
+                                       href="./?server=<?php echo $server ?>&tube=<?php echo $tube ?>&state=<?php echo $state ?>&action=deleteJob&jobid=<?php echo $job['id'];?>"><i
                                             class="glyphicon glyphicon-remove glyphicon-white"></i> Delete</a>
                                 </div>
                             </div>

--- a/lib/tpl/currentTubeSearchResults.php
+++ b/lib/tpl/currentTubeSearchResults.php
@@ -3,7 +3,7 @@ $searchResults = $console->getSearchResult();
 include('currentTubeJobsSummaryTable.php');
 ?>
 <section id="actionsRow">
-    <a class="btn btn-default btn-sm" href="?server=<?php echo $server ?>&tube=<?php echo $tube ?>"><i class="glyphicon glyphicon-backward"></i>  &nbsp;Back to tube</a>
+    <a class="btn btn-default btn-sm" href="./?server=<?php echo $server ?>&tube=<?php echo $tube ?>"><i class="glyphicon glyphicon-backward"></i>  &nbsp;Back to tube</a>
 </section>
 <?php
 if ($searchResults['total'] > 0) {
@@ -36,17 +36,17 @@ if ($searchResults['total'] > 0) {
                                             </button>
                                             <ul class="dropdown-menu" role="menu" aria-labelledby="dropdownMenu1">
                                                 <li role="presentation"><a role="menuitem" class="addSample" data-jobid="<?php echo $job->getId(); ?>"
-                                                                           href="?server=<?php echo $server ?>&tube=<?php echo $tube ?>&action=addSample">
+                                                                           href="./?server=<?php echo $server ?>&tube=<?php echo $tube ?>&action=addSample">
                                                         <i class="glyphicon glyphicon-plus glyphicon-white"></i>
                                                         Add to samples</a>
                                                 </li>
-                                                <li role="presentation"><a role="menuitem" 
-                                                                           href="?server=<?php echo $server ?>&tube=<?php echo $tube ?>&state=<?php echo $state ?>&action=deleteJob&jobid=<?php echo $job->getId(); ?>"><i
+                                                <li role="presentation"><a role="menuitem"
+                                                                           href="./?server=<?php echo $server ?>&tube=<?php echo $tube ?>&state=<?php echo $state ?>&action=deleteJob&jobid=<?php echo $job->getId(); ?>"><i
                                                             class="glyphicon glyphicon-remove glyphicon-white"></i>
                                                         Delete</a>
                                                 </li>
-                                                <li role="presentation"><a role="menuitem" 
-                                                                           href="?server=<?php echo $server ?>&tube=<?php echo $tube ?>&state=<?php echo $state ?>&action=kickJob&jobid=<?php echo $job->getId(); ?>"><i
+                                                <li role="presentation"><a role="menuitem"
+                                                                           href="./?server=<?php echo $server ?>&tube=<?php echo $tube ?>&state=<?php echo $state ?>&action=kickJob&jobid=<?php echo $job->getId(); ?>"><i
                                                             class="glyphicon glyphicon-forward glyphicon-white"></i>
                                                         Kick</a>
                                                 </li>

--- a/lib/tpl/main.php
+++ b/lib/tpl/main.php
@@ -15,7 +15,7 @@ $servers = $console->getServers();
         <link href="css/customer.css" rel="stylesheet">
         <link href="highlight/styles/magula.css" rel="stylesheet">
         <script>
-            var url = "./index.php?server=<?php echo $server ?>";
+            var url = "./?server=<?php echo $server ?>";
             var contentType = "<?php echo isset($contentType) ? $contentType : '' ?>";
         </script>
 
@@ -42,7 +42,7 @@ $servers = $console->getServers();
                             <span class="icon-bar"></span>
                             <span class="icon-bar"></span>
                         </button>
-                        <a class="navbar-brand" href="index.php">Beanstalk console</a>
+                        <a class="navbar-brand" href="./?">Beanstalk console</a>
                     </div>
                     <div class="collapse navbar-collapse">
                         <ul class="nav navbar-nav">
@@ -53,9 +53,9 @@ $servers = $console->getServers();
                                         <?php echo $server ?> <span class="caret"></span>
                                     </a>
                                     <ul class="dropdown-menu">
-                                        <li><a href="index.php">All servers</a></li>
+                                        <li><a href="./?">All servers</a></li>
                                         <?php foreach (array_diff($servers, array($server)) as $serverItem): ?>
-                                            <li><a href="index.php?server=<?php echo $serverItem ?>"><?php echo $serverItem ?></a></li>
+                                            <li><a href="./?server=<?php echo $serverItem ?>"><?php echo $serverItem ?></a></li>
                                         <?php endforeach ?>
                                     </ul>
                                 </li>
@@ -64,9 +64,9 @@ $servers = $console->getServers();
                                         <?php echo $tube ?> <span class="caret"></span>
                                     </a>
                                     <ul class="dropdown-menu">
-                                        <li><a href="index.php?server=<?php echo $server ?>">All tubes</a></li>
+                                        <li><a href="./?server=<?php echo $server ?>">All tubes</a></li>
                                         <?php foreach (array_diff($tubes, array($tube)) as $tubeItem): ?>
-                                            <li><a href="index.php?server=<?php echo $server ?>&tube=<?php echo $tubeItem ?>"><?php echo $tubeItem ?></a></li>
+                                            <li><a href="./?server=<?php echo $server ?>&tube=<?php echo $tubeItem ?>"><?php echo $tubeItem ?></a></li>
                                         <?php endforeach ?>
                                     </ul>
                                 </li>
@@ -76,9 +76,9 @@ $servers = $console->getServers();
                                         <?php echo $server ?> <span class="caret"></span>
                                     </a>
                                     <ul class="dropdown-menu">
-                                        <li><a href="index.php">All servers</a></li>
+                                        <li><a href="./?">All servers</a></li>
                                         <?php foreach (array_diff($servers, array($server)) as $serverItem): ?>
-                                            <li><a href="index.php?server=<?php echo $serverItem ?>"><?php echo $serverItem ?></a></li>
+                                            <li><a href="./?server=<?php echo $serverItem ?>"><?php echo $serverItem ?></a></li>
                                         <?php endforeach ?>
                                     </ul>
                                 </li>
@@ -91,7 +91,7 @@ $servers = $console->getServers();
                                         if (isset($tubes) && is_array($tubes)) {
                                             foreach ($tubes as $tubeItem) {
                                                 ?>
-                                                <li><a href="index.php?server=<?php echo $server ?>&tube=<?php echo $tubeItem ?>"><?php echo $tubeItem ?></a></li>
+                                                <li><a href="./?server=<?php echo $server ?>&tube=<?php echo $tubeItem ?>"><?php echo $tubeItem ?></a></li>
                                             <?php }
                                         }
                                         ?>
@@ -105,7 +105,7 @@ $servers = $console->getServers();
                                     </a>
                                     <ul class="dropdown-menu">
                                         <?php foreach ($servers as $serverItem): ?>
-                                            <li><a href="index.php?server=<?php echo $serverItem ?>"><?php echo $serverItem ?></a></li>
+                                            <li><a href="./?server=<?php echo $serverItem ?>"><?php echo $serverItem ?></a></li>
         <?php endforeach ?>
                                     </ul>
                                 </li>
@@ -128,7 +128,7 @@ $servers = $console->getServers();
                                         ?>
                                         <li><a href="#clear-tubes" role="button" data-toggle="modal">Clear multiple tubes</a></li>
     <?php } ?>
-                                    <li><a href="index.php?action=manageSamples" role="button">Manage samples</a></li>
+                                    <li><a href="./?action=manageSamples" role="button">Manage samples</a></li>
                                     <li class="divider"></li>
                                     <li><a href="#settings" role="button" data-toggle="modal">Edit settings</a></li>
                                 </ul>

--- a/lib/tpl/sampleJobsEdit.php
+++ b/lib/tpl/sampleJobsEdit.php
@@ -19,7 +19,7 @@ if (isset($isNewRecord) && $isNewRecord) {
             <?php } ?>
         </div>
         <div class="pull-right">
-            <a href="?action=manageSamples" class="btn btn-default btn-small"><i class="glyphicon glyphicon-list"></i> Manage samples</a>
+            <a href="./?action=manageSamples" class="btn btn-default btn-small"><i class="glyphicon glyphicon-list"></i> Manage samples</a>
         </div>
     </div>
     <div class=" form-group">

--- a/lib/tpl/sampleJobsManage.php
+++ b/lib/tpl/sampleJobsManage.php
@@ -22,7 +22,7 @@ if (!empty($sampleJobs)) {
     ?>
     <div class="clearfix">
         <div class="pull-right">
-            <a href="?action=newSample" class="btn btn-default btn-sm"><i class="glyphicon glyphicon-plus"></i> Add job to samples</a>
+            <a href="./?action=newSample" class="btn btn-default btn-sm"><i class="glyphicon glyphicon-plus"></i> Add job to samples</a>
         </div>
     </div>
     <section id="summaryTable">
@@ -38,7 +38,7 @@ if (!empty($sampleJobs)) {
             <?php foreach ($sampleJobs as $key => $job): ?>
                 <tr>
                     <td name="<?php echo $key ?>" style="line-height: 25px !important;"><a
-                                href="?action=editSample&key=<?php echo $key ?>"><?php echo htmlspecialchars($job['name']); ?></a></td>
+                                href="./?action=editSample&key=<?php echo $key ?>"><?php echo htmlspecialchars($job['name']); ?></a></td>
                     <td>
                         <?php
                         if (is_array($job['tubes'])) {
@@ -46,7 +46,7 @@ if (!empty($sampleJobs)) {
                                 if (isset($_server) && !empty($_server)) {
                                     ?>
                                     <a class="btn btn-default  btn-sm"
-                                       href="?server=<?php echo $_server ?>&tube=<?php echo $tubename ?>&action=loadSample&key=<?php echo $key; ?>&redirect=<?php echo urlencode('index.php?action=manageSamples'); ?>"><i
+                                       href="./?server=<?php echo $_server ?>&tube=<?php echo $tubename ?>&action=loadSample&key=<?php echo $key; ?>&redirect=<?php echo urlencode('./?action=manageSamples'); ?>"><i
                                                 class="glyphicon glyphicon-forward"></i> <?php echo $tubename; ?></a>
                                 <?php
                                 } else {
@@ -62,7 +62,7 @@ if (!empty($sampleJobs)) {
                                                 foreach ($_servers as $server2) {
                                                     ?>
                                                     <li>
-                                                        <a href="?server=<?php echo $server2 ?>&tube=<?php echo $tubename ?>&action=loadSample&key=<?php echo $key; ?>&redirect=<?php echo urlencode('index.php?action=manageSamples'); ?>"><?php echo $server2; ?></a>
+                                                        <a href="./?server=<?php echo $server2 ?>&tube=<?php echo $tubename ?>&action=loadSample&key=<?php echo $key; ?>&redirect=<?php echo urlencode('./?action=manageSamples'); ?>"><?php echo $server2; ?></a>
                                                     </li>
                                                 <?php
                                                 }
@@ -78,8 +78,8 @@ if (!empty($sampleJobs)) {
                     </td>
                     <td>
                         <div class="pull-right">
-                            <a class="btn btn-default btn-sm" href="?action=editSample&key=<?php echo $key ?>"><i class="glyphicon glyphicon-pencil"></i> Edit</a>
-                            <a class="btn btn-default btn-sm" href="?action=deleteSample&key=<?php echo $key ?>"><i class="glyphicon glyphicon-trash"></i> Delete</a>
+                            <a class="btn btn-default btn-sm" href="./?action=editSample&key=<?php echo $key ?>"><i class="glyphicon glyphicon-pencil"></i> Edit</a>
+                            <a class="btn btn-default btn-sm" href="./?action=deleteSample&key=<?php echo $key ?>"><i class="glyphicon glyphicon-trash"></i> Delete</a>
                         </div>
                     </td>
                 </tr>

--- a/lib/tpl/serversList.php
+++ b/lib/tpl/serversList.php
@@ -46,7 +46,7 @@ if (!empty($servers)):
                             <?php if (empty($stats)): ?>
                                 <td style="white-space: nowrap;"><?php echo $label ?></td>
                             <?php else: ?>
-                                <td  style="white-space: nowrap;"><a href="?server=<?php echo $server ?>"><?php echo $label; ?></a></td>
+                                <td  style="white-space: nowrap;"><a href="./?server=<?php echo $server ?>"><?php echo $label; ?></a></td>
                             <?php endif ?>
                             <?php foreach ($stats as $key => $item): ?>
                                 <td class="<?php if (!in_array($key, $visible)) echo 'hide' ?>"
@@ -56,7 +56,7 @@ if (!empty($servers)):
                                 <td colspan="<?php echo count($visible) ?>" class="row-full">&nbsp;</td>
                             <?php endif ?>
                             <td><?php if (array_intersect(array($server), $cookieServers)): ?>
-                                    <a class="btn btn-xs btn-danger" title="Remove from list" href="?action=serversRemove&removeServer=<?php echo $server ?>"><span
+                                    <a class="btn btn-xs btn-danger" title="Remove from list" href="./?action=serversRemove&removeServer=<?php echo $server ?>"><span
                                             class="glyphicon glyphicon-minus"></span></a>
                                     <?php endif; ?>
                             </td>


### PR DESCRIPTION
changes:
- typecasted `$peek` to array because sometimes it arrives as `null` in the template
    - This was causing a warning at seemingly random page loads.
    - ![added array typecast for possible null](https://cloud.githubusercontent.com/assets/4094542/19169514/7cf53fc8-8bda-11e6-88ea-93bf0648f389.PNG)
    - ![array typecast of null becomes empty array](https://cloud.githubusercontent.com/assets/4094542/19169576/b3377aa6-8bda-11e6-93fa-86e9ca2d4852.PNG)

- changed occurrences of `index.php?`, `?`, and `index.php` to `./?`. I assume this needs a lot of explanation. 
    - I have an `<iframe />` on `GET /admin/queues`. This iframe calls the URL for [npm express-http-proxy](https://www.npmjs.com/package/express-http-proxy) that merely checks the user is a site admin, then proxies deeper into the backend where the `beanstalk_console` is actually hosted. The back-end URL for that is `/api/admin/beanstalkd/{index.php,assets,etc..}`. Some variations of `index.php?`, `?`, and `index.php`  occurrences were not compatible with proxying with a prefix. While this will most likely not harm or benefit the major of users, this change is good because the code base will now be more consistent and support proxied+prefixed embedding.
    - The goal of this is to supply my clients and less technical administrators with the beakstalkd console while seeming integrated into the application and while using the application's authentication system