### PR TITLE
Load configs from local_config.php

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /vendor
 .vagrant
 nbproject/
+local_config.php

--- a/config.php
+++ b/config.php
@@ -22,3 +22,12 @@ $GLOBALS['config'] = array(
      */
     'version' => '1.7.6',
 );
+
+/**
+ * You can also put your overrides in local_config.php
+ */
+
+$local_config = dirname(__FILE__) . DIRECTORY_SEPARATOR . 'local_config.php';
+if(file_exists($local_config) && is_file($local_config)) {
+    include $local_config;
+}


### PR DESCRIPTION
Hello! I modified `config.php` to load `local_config.php` if it exists, which lets me keep my configuration separate from the rest of the repo. What do you think?