### PR TITLE
Replacing __autoload with spl_autoload_register for PHP 7.2 compatbility

### DIFF
--- a/lib/include.php
+++ b/lib/include.php
@@ -5,9 +5,11 @@
  * @link http://kr.github.com/beanstalkd/
  * @author Petr Trofimov, Sergey Lysenko
  */
-function __autoload($class) {
+function autoload_class($class) {
     require_once str_replace('_', '/', $class) . '.php';
 }
+
+spl_autoload_register('autoload_class');
 
 session_start();
 require_once 'Pheanstalk/ClassLoader.php';


### PR DESCRIPTION
This fixes https://github.com/ptrofimov/beanstalk_console/issues/149 by following the recommendation for porting code over from the old autoload method defined in the PHP docs: http://php.net/manual/en/function.spl-autoload-register.php

I did some quick smoke testing of other functionality and don't see anything else that doesn't work with PHP 7.2, but having automated tests would help.