### PR TITLE
Add button to tube page to kick all buried jobs

### DIFF
--- a/lib/tpl/currentTubeJobs.php
+++ b/lib/tpl/currentTubeJobs.php
@@ -4,6 +4,7 @@ $fields = $console->getTubeStatFields();
 $groups = $console->getTubeStatGroups();
 $visible = $console->getTubeStatVisible();
 $sampleJobs = $console->getSampleJobs($tube);
+$allStats = $console->getTubeStatValues($tube);
 
 if (!@empty($_COOKIE['tubePauseSeconds'])) {
     $tubePauseSeconds = intval($_COOKIE['tubePauseSeconds']);

--- a/lib/tpl/currentTubeJobsActionsRow.php
+++ b/lib/tpl/currentTubeJobsActionsRow.php
@@ -1,5 +1,6 @@
 <?php
 $sampleJobs = $console->getSampleJobs($tube);
+$buriedJobsCount = $allStats['current-jobs-buried'];
 
 if (!@empty($_COOKIE['tubePauseSeconds'])) {
     $tubePauseSeconds = intval($_COOKIE['tubePauseSeconds']);
@@ -20,6 +21,8 @@ if (!@empty($_COOKIE['tubePauseSeconds'])) {
             <input id="kick_tube_no_<?php echo md5($tube);?>" type="number" value="10" name="count" min="0" step="1" size="4" class="btn btn-default btn-sm kick_jobs_no">
         </div>
     </form>
+
+    <a class="btn btn-default btn-sm" href="./?server=<?php echo $server ?>&tube=<?php echo urlencode($tube) ?>&action=kick&count=<?=$buriedJobsCount?>"><i class="glyphicon glyphicon-forward"></i> Kick all jobs</a>
 
     <?php
     if (empty($tubeStats['pause-time-left'])) {


### PR DESCRIPTION
Add a single button to kick all buried jobs without having to use the input box to enter the exact number manually.

![image](https://user-images.githubusercontent.com/4541238/46894978-5d30be00-ce6e-11e8-9ba4-809eb70b8f89.png)
