### PR TITLE
Highlight buried jobs by changing their color and background-color.

### DIFF
--- a/lib/tpl/allTubes.php
+++ b/lib/tpl/allTubes.php
@@ -27,9 +27,19 @@ $visible = $console->getTubeStatVisible();
                             <?php $tubeStats = $console->getTubeStatValues($tubeItem) ?>
                             <?php
                             foreach ($fields as $key => $item):
-                                $markHidden = !in_array($key, $visible) ? ' class="hide"' : '';
+                                $classes = array("td-$key");
+                                if (!in_array($key, $visible)) {
+                                    $classes[] = 'hide' ;
+                                }
+                                if (isset($tubeStats[$key]) && $tubeStats[$key] != '0') {
+                                    $classes[] = 'hasValue';
+                                }
+                                $cssClass = '' ;
+                                if (count($classes) > 0) {
+                                    $cssClass = ' class = "' . join(' ', $classes) . '"' ;
+                                }
                                 ?>
-                                <td<?php echo $markHidden ?>><?php echo isset($tubeStats[$key]) ? $tubeStats[$key] : '' ?></td>
+                                <td<?php echo $cssClass ?>><?php echo isset($tubeStats[$key]) ? $tubeStats[$key] : '' ?></td>
                             <?php endforeach; ?>
                         </tr>
                     <?php endforeach ?>

--- a/lib/tpl/currentTubeJobsSummaryTable.php
+++ b/lib/tpl/currentTubeJobsSummaryTable.php
@@ -30,9 +30,19 @@ $visible = $console->getTubeStatVisible();
                             <?php $tubeStats = $console->getTubeStatValues($tubeItem) ?>
                             <?php
                             foreach ($fields as $key => $item):
-                                $markHidden = !in_array($key, $visible) ? ' class="hide"' : '';
+                                $classes = array("td-$key");
+                                if (!in_array($key, $visible)) {
+                                    $classes[] = 'hide' ;
+                                }
+                                if (isset($tubeStats[$key]) && $tubeStats[$key] != '0') {
+                                    $classes[] = 'hasValue';
+                                }
+                                $cssClass = '' ;
+                                if (count($classes) > 0) {
+                                    $cssClass = ' class = "' . join(' ', $classes) . '"' ;
+                                }
                                 ?>
-                                <td<?php echo $markHidden ?>><?php echo isset($tubeStats[$key]) ? $tubeStats[$key] : '' ?></td>
+                                <td<?php echo $cssClass ?>><?php echo isset($tubeStats[$key]) ? $tubeStats[$key] : '' ?></td>
                             <?php endforeach; ?>
                         </tr>
                     <?php endforeach ?>

--- a/lib/tpl/serversList.php
+++ b/lib/tpl/serversList.php
@@ -49,7 +49,20 @@ if (!empty($servers)):
                                 <td  style="white-space: nowrap;"><a href="./?server=<?php echo $server ?>"><?php echo $label; ?></a></td>
                             <?php endif ?>
                             <?php foreach ($stats as $key => $item): ?>
-                                <td class="<?php if (!in_array($key, $visible)) echo 'hide' ?>"
+                                <?php
+                                $classes = array("td-$key");
+                                if (!in_array($key, $visible)) {
+                                    $classes[] = 'hide' ;
+                                }
+                                if (isset($stats[$key]) && $stats[$key] != '0') {
+                                    $classes[] = 'hasValue';
+                                }
+                                $cssClass = '' ;
+                                if (count($classes) > 0) {
+                                    $cssClass = ' class = "' . join(' ', $classes) . '"' ;
+                                }
+                                ?>
+                                <td <?php echo $cssClass; ?>
                                     name="<?php echo $key ?>"><?php echo htmlspecialchars($item['value']) ?></td>
                                 <?php endforeach ?>
                                 <?php if (empty($stats)): ?>

--- a/public/css/customer.css
+++ b/public/css/customer.css
@@ -67,3 +67,10 @@ ol.inside, ul.inside {
 .navbar-inverse .a-unstyled:visited { color: inherit; text-decoration: none; }
 .navbar-inverse .a-unstyled:hover { color: inherit; text-decoration: none; }
 .navbar-inverse .a-unstyled:active { color: inherit; text-decoration: none; }
+
+/** Highlight buried jobs */
+#summaryTable * td.td-current-jobs-buried.hasValue, #servers-index * td.td-current-jobs-buried.hasValue {
+    color: darkred;
+    font-weight: bolder;
+    background-color: #ffdddd;
+}

--- a/public/js/customer.js
+++ b/public/js/customer.js
@@ -338,6 +338,12 @@ $(document).ready(
                         }).animate({
                             'background-color': color
                         }, 500);
+                        if (l.trim() != '0') {
+                            $td1.addClass('hasValue');
+                        }
+                        else {
+                            $td1.removeClass('hasValue');
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Mark up table columns by type of stat (buried, reserved etc) and add CSS to highlight buried ones so they're easier to spot when looking at a long list of tubes. Automatic refreshing is supported.

This works on all the views: servers listing, tubes listing, and single tube.

![beanstalk3](https://user-images.githubusercontent.com/562545/70136424-a6585880-1694-11ea-8d33-7a2f4b7909b8.png)

![beanstalk2](https://user-images.githubusercontent.com/562545/70136427-a6f0ef00-1694-11ea-8657-c7324581df78.png)

![beanstalk1](https://user-images.githubusercontent.com/562545/70136422-a6585880-1694-11ea-8e46-8d835f7bbd3e.png)

