### PR TITLE
Fix reference to precise64 box in Vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,8 +4,8 @@
 VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-	config.vm.box = "precise64"
-	config.vm.box_url = "http://files.vagrantup.com/precise64.box"
+	config.vm.box = "hashicorp/precise64"
+	config.vm.box_url = "https://vagrantcloud.com/hashicorp/boxes/precise64/versions/1.1.0/providers/virtualbox.box"
 
 	# expose ports
 	config.vm.network :forwarded_port, host: 7654, guest: 80


### PR DESCRIPTION
The link to the vagrant box is dead. This will fix it, so `vagrant up` works again.

Before:
```
$ vagrant up     
Bringing machine 'default' up with 'virtualbox' provider...
==> default: Box 'precise64' could not be found. Attempting to find and install...
    default: Box Provider: virtualbox
    default: Box Version: >= 0
==> default: Box file was not detected as metadata. Adding it directly...
==> default: Adding box 'precise64' (v0) for provider: virtualbox
    default: Downloading: http://files.vagrantup.com/precise64.box
Download redirected to host: hashicorp-files.hashicorp.com
An error occurred while downloading the remote file. The error
message, if any, is reproduced below. Please fix this error and try
again.

Failed to connect to hashicorp-files.hashicorp.com port 443: Connection refused
```

After:
```
$ vagrant up     
Bringing machine 'default' up with 'virtualbox' provider...
==> default: Box 'hashicorp/precise64' could not be found. Attempting to find and install...
    default: Box Provider: virtualbox
    default: Box Version: >= 0
==> default: Box file was not detected as metadata. Adding it directly...
==> default: Adding box 'hashicorp/precise64' (v0) for provider: virtualbox
    default: Downloading: https://vagrantcloud.com/hashicorp/boxes/precise64/versions/1.1.0/providers/virtualbox.box
Download redirected to host: vagrantcloud-files-production.s3.amazonaws.com
==> default: Successfully added box 'hashicorp/precise64' (v0) for 'virtualbox'!
==> default: Importing base box 'hashicorp/precise64'...