### PR TITLE
Highlight paused tubes

### DIFF
--- a/lib/tpl/allTubes.php
+++ b/lib/tpl/allTubes.php
@@ -21,10 +21,12 @@ $visible = $console->getTubeStatVisible();
                 </thead>
                 <tbody>
                     <?php foreach ((is_array($tubes) ? $tubes : array()) as $tubeItem): ?>
-                        <tr>
-                            <td name="<?php echo $key ?>"><a href="./?server=<?php echo $server ?>&tube=<?php echo urlencode($tubeItem) ?>"><?php echo $tubeItem ?></a>
+                        <?php $tubeStats = $console->getTubeStatValues($tubeItem) ?>
+                        <tr class="<?php echo ($tubeStats['pause-time-left'] > '0')? 'tr-tube-paused': ''; ?>"
+                            title="<?php echo ($tubeStats['pause-time-left'] > '0')? 'Pause seconds left: ' . $tubeStats['pause-time-left'] : ''; ?>"
+                            >
+                            <td id="<?php echo 'tube-' . $tubeItem ?>"><a href="./?server=<?php echo $server ?>&tube=<?php echo urlencode($tubeItem) ?>"><?php echo $tubeItem ?></a>
                             </td>
-                            <?php $tubeStats = $console->getTubeStatValues($tubeItem) ?>
                             <?php
                             foreach ($fields as $key => $item):
                                 $classes = array("td-$key");

--- a/lib/tpl/currentTubeJobsSummaryTable.php
+++ b/lib/tpl/currentTubeJobsSummaryTable.php
@@ -25,9 +25,11 @@ $visible = $console->getTubeStatVisible();
                 </thead>
                 <tbody>
                     <?php foreach (array($tube) as $tubeItem): ?>
-                        <tr>
-                            <td name="<?php echo $key ?>"><?php echo $tubeItem ?></td>
-                            <?php $tubeStats = $console->getTubeStatValues($tubeItem) ?>
+                        <?php $tubeStats = $console->getTubeStatValues($tubeItem) ?>
+                        <tr class="<?php echo ($tubeStats['pause-time-left'] > '0')? 'tr-tube-paused': ''; ?>"
+                            title="<?php echo ($tubeStats['pause-time-left'] > '0')? 'Pause seconds left: ' . $tubeStats['pause-time-left'] : ''; ?>"
+                            >
+                            <td id="<?php echo 'tube-' . $tubeItem ?>"><?php echo $tubeItem ?></td>
                             <?php
                             foreach ($fields as $key => $item):
                                 $classes = array("td-$key");

--- a/public/css/customer.css
+++ b/public/css/customer.css
@@ -81,3 +81,8 @@ ol.inside, ul.inside {
     font-weight: bolder;
     background-color: #FFF3DD;
 }
+
+/** Highlight paused tubes */
+tr.tr-tube-paused {
+    border-left: 6px solid #FFA49A;
+}


### PR DESCRIPTION
Highlight paused tubes by changing their border-left colour and show the remaining seconds in a tooltip. Automatic refreshing is supported.

This works on the views: tubes listing and single tube. Server-listing doesn't have access to that information, it would need to query all its tubes.


Also:
Fix minor HTML bug, <td> can't have "name" attribute so changed to "id".

![2020-11-16 13_56_20-10 10 3 30_11300 - Beanstalk console](https://user-images.githubusercontent.com/562545/99250089-d0f2e100-2813-11eb-9464-5f176667dec2.jpg)

![2020-11-16 13_56_13-NL-PAYINFO-FILE - 10 10 3 30_11300 - Beanstalk console](https://user-images.githubusercontent.com/562545/99250088-cfc1b400-2813-11eb-83fd-5906f30d3b21.jpg)



