### PR TITLE
Fix PHP version into Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:5.6-apache
+FROM php:7.1-apache
 LABEL maintainer="Rion Dooley <dooley@tacc.utexas.edu>"
 
 ENV APACHE_DOCROOT "/var/www"


### PR DESCRIPTION
Fix PHP version into Dockerfile, because project is using feature null coalescing operator, present in version 7.0 of PHP.

This operation is present into https://github.com/ptrofimov/beanstalk_console/blob/master/lib/include.php#L419 as example.

I tested this Dockerfile and it's working fine, as you can see below: 

https://hub.docker.com/layers/devbox/joubertredrat/devbox/ptrofimov-beanstalk-console-1.7.15/images/sha256-76d04d01ca790913c62fb2ed37250a23064d3d74a60ca71fb7c7c7ae29d5c66d?context=repo

Reference: https://www.php.net/manual/en/migration70.new-features.php#migration70.new-features.null-coalesce-op