### PR TITLE
Fix "Undefined variable $serverLabel" warning in php 8+

### DIFF
--- a/lib/tpl/main.php
+++ b/lib/tpl/main.php
@@ -14,7 +14,7 @@ if ($server) {
 
         <title>
             <?php if ($tube) echo $tube . ' - ' ?>
-            <?php echo $serverLabel ? $serverLabel : 'All servers' ?> -
+            <?php echo !empty($serverLabel) ? $serverLabel : 'All servers' ?> -
             Beanstalk console
         </title>
 


### PR DESCRIPTION
In php 8 or newer a number of notices have been converted into warnings. See for more details: https://www.php.net/manual/en/migration80.incompatible.php
On the landing page the following warning is thrown into the title: "Warning: Undefined variable $serverLabel in ib/tpl/main.php on line 17"