### PR TITLE
use a named php session (session_name(...))

### DIFF
--- a/lib/include.php
+++ b/lib/include.php
@@ -11,6 +11,7 @@ function autoload_class($class) {
 
 spl_autoload_register('autoload_class');
 
+session_name('beanstalkconsole');
 session_start();
 require_once 'Pheanstalk/ClassLoader.php';
 Pheanstalk_ClassLoader::register(dirname(__FILE__));


### PR DESCRIPTION
Define a unique name for the PHP session cookie to avoid clashing with another application running on the same virtualhost / hostname.

Adds: `session_name('something');` before `session_start()`;

(Yes the other app could rename it's session too ... but this might affect others anyway).