### PR TITLE
Added config option for not showing errors in the frontend

### DIFF
--- a/config.php
+++ b/config.php
@@ -18,6 +18,10 @@ $GLOBALS['config'] = array(
         'password' => 'password',
     ),
     /**
+     * Activate/deactive displaying errors
+     */
+    'displayErrors' => true,
+    /**
      * Version number
      */
     'version' => '1.7.21',

--- a/public/index.php
+++ b/public/index.php
@@ -5,24 +5,26 @@
  * @link http://kr.github.com/beanstalkd/
  * @author Petr Trofimov, Sergey Lysenko
  */
-error_reporting(E_ALL & ~E_NOTICE);
-ini_set('display_errors', 1);
 
 require_once dirname(__FILE__) . '/../config.php';
+
+error_reporting(E_ALL & ~E_NOTICE);
+ini_set('display_errors', $config['displayErrors'] ?? true);
+
 $authenticated = false;
 
-if( isset($_GET['logout']) && $_GET['logout']){
+if (isset($_GET['logout']) && $_GET['logout']) {
     $_SERVER['PHP_AUTH_USER'] = '';
     $_SERVER['PHP_AUTH_PW'] = '';
 }
 if (
-        isset($config['auth']) &&
-        isset($config['auth']['enabled']) &&
-        $config['auth']['enabled'] &&
-        isset($_SERVER['PHP_AUTH_USER']) &&
-        isset($_SERVER['PHP_AUTH_PW']) &&
-        $_SERVER['PHP_AUTH_USER'] == $config['auth']['username'] &&
-        $_SERVER['PHP_AUTH_PW'] == $config['auth']['password']
+    isset($config['auth']) &&
+    isset($config['auth']['enabled']) &&
+    $config['auth']['enabled'] &&
+    isset($_SERVER['PHP_AUTH_USER']) &&
+    isset($_SERVER['PHP_AUTH_PW']) &&
+    $_SERVER['PHP_AUTH_USER'] == $config['auth']['username'] &&
+    $_SERVER['PHP_AUTH_PW'] == $config['auth']['password']
 ) {
     $authenticated = true;
 }


### PR DESCRIPTION
This pr implements a simple way to remove all errors from the frontend. The change is requested because when working with a lot of tubes that changes from being shown to not being shown, sometimes would throw a lot of errors.

This is essentially the first of three pr's related to fixing this issue, but they have been split up into three different functional parts

the settings has been defaulted to have the same behaviour as it already is.

This is my first contribution pr, so please do say if i am missing anything or have forgotten to add something :)