### PR TITLE
Adding reuse of already fetched tubes

### DIFF
--- a/lib/BeanstalkInterface.class.php
+++ b/lib/BeanstalkInterface.class.php
@@ -3,6 +3,7 @@
 class BeanstalkInterface {
 
     protected $_contentType;
+    protected $_tubes;
     public $_client;
 
     public function __construct($server) {
@@ -21,6 +22,7 @@ class BeanstalkInterface {
     public function getTubes() {
         $tubes = $this->_client->listTubes();
         sort($tubes);
+        $this->_tubes = $tubes;
         return $tubes;
     }
 
@@ -93,7 +95,7 @@ class BeanstalkInterface {
 
     public function getTubesStats() {
         $stats = array();
-        foreach ($this->getTubes() as $tube) {
+        foreach ($this->_tubes ?? $this->getTubes() as $tube) {
             $stats[$tube] = $this->getTubeStats($tube);
         }
         return $stats;
@@ -235,7 +237,7 @@ class BeanstalkInterface {
             // restore old error handler
             restore_error_handler();
         }
-        
+
         if (@$_COOKIE['isDisabledUnserialization'] != 1) {
             $mixed = set_error_handler(array($this, 'exceptions_error_handler'));
             try {


### PR DESCRIPTION
When getting tubeStats the tubes has already been fetched right before. As the tubeStats (in setup) sometimes failes to connect and thereby fails in receiving the excpected data, this request is proposed as an optimization to reuse the already fetched tube names if they already exists.

This is the second of three pr's to fix an issue where a lot of errors where being thrown when having a lot of tubes are not always being run by a process.

This is my first set of contribution pr's, so please do say if i am missing anything or have forgotten to add something :)