### PR TITLE
Adding settings for beanstalk fetch retries

### DIFF
--- a/config.php
+++ b/config.php
@@ -18,6 +18,25 @@ $GLOBALS['config'] = array(
         'password' => 'password',
     ),
     /**
+     * Optional retry configuration for retrying data fetching from beanstalk
+     */
+    'retry' => [
+        /**
+         * Retry failed beanstalk data fetching if hitting a server exception
+         */
+        'shouldRetry' => false,
+        /**
+         * Max amount of tries it will make when trying to fetch beanstalk data, each with a default delay of 250ms.
+         * It is ignored if shouldRetry is false
+         */
+        'maxTries' => 2,
+        /**
+         * Custom delay in milliseconds between each fetch retry (default 250ms)
+         * It is ignored if shouldRetry is false
+        */
+        'delay' => 250
+    ],
+    /**
      * Version number
      */
     'version' => '1.7.21',

--- a/lib/tpl/allTubes.php
+++ b/lib/tpl/allTubes.php
@@ -27,7 +27,7 @@ $visible = $console->getTubeStatVisible();
                             $arr_tubeStats = $_SESSION['oldTubeStats'][$tubeItem];
                         } else if (!empty($arr_tubeStats)) {
                             if(!isset($_SESSION['oldTubesStats'])) {
-                                $_SESSION['oldTubesStats'] = [];
+                                $_SESSION['oldTubesStats'] = array();
                             }
                             $_SESSION['oldTubeStats'][$tubeItem] = $arr_tubeStats;
                         }

--- a/lib/tpl/allTubes.php
+++ b/lib/tpl/allTubes.php
@@ -22,14 +22,22 @@ $visible = $console->getTubeStatVisible();
                 <tbody>
                     <?php foreach ((is_array($tubes) ? $tubes : array()) as $tubeItem): ?>
                         <?php
-                        $arr_tubeStats = $tplVars['tubesStats'][$tubeItem];
+                        $arr_tubeStats = $tplVars['tubesStats'][$tubeItem] ?? array();
+                        if(empty($arr_tubeStats) && isset($_SESSION['oldTubeStats'][$tubeItem])) {
+                            $arr_tubeStats = $_SESSION['oldTubeStats'][$tubeItem];
+                        } else if (!empty($arr_tubeStats)) {
+                            if(!isset($_SESSION['oldTubesStats'])) {
+                                $_SESSION['oldTubesStats'] = [];
+                            }
+                            $_SESSION['oldTubeStats'][$tubeItem] = $arr_tubeStats;
+                        }
                         $tubeStats = array();
                         foreach ($arr_tubeStats as $key => $arr) {
                             $tubeStats[$key] = $arr['value'];
                         }
                         ?>
-                        <tr class="<?php echo ($tubeStats['pause-time-left'] > '0') ? 'tr-tube-paused' : ''; ?>"
-                            title="<?php echo ($tubeStats['pause-time-left'] > '0') ? 'Pause seconds left: ' . $tubeStats['pause-time-left'] : ''; ?>"
+                        <tr class="<?php echo (isset($tubeStats['pause-time-left']) && $tubeStats['pause-time-left'] > '0') ? 'tr-tube-paused' : ''; ?>"
+                            title="<?php echo (isset($tubeStats['pause-time-left']) && $tubeStats['pause-time-left'] > '0') ? 'Pause seconds left: ' . $tubeStats['pause-time-left'] : ''; ?>"
                             >
                             <td id="<?php echo 'tube-' . htmlspecialchars($tubeItem) ?>"><a href="./?server=<?php echo urlencode($server) ?>&tube=<?php echo urlencode($tubeItem) ?>"><?php echo htmlspecialchars($tubeItem) ?></a>
                             </td>


### PR DESCRIPTION
This pr request to implement some new options for making multiple retries upon server exceptions.

These changes are request as the server setup i work on in my day job runs a lot of tubes which sometimes is not active, which makes it so that the tube is not existing anymore. Sometimes connections will fail for just a very breaf moment, so the option to add some simple retries will not be notisable when using the console but will help a lot.

This is the third pr to fix a lot of issues i see on a daily basis in our setup when working with this console.

the settings has been defaulted to have the same behaviour as it already is.

3 things will be requested added with this pr.

1. Adding new config options and code to making data retry possible and tweak the settings of how often and how many times
2. Storing statsTube data in the session mostly for reuse when auto refreshing and statsTube sometimes can be missing because of server exceptions
3. Some minor bug fixes and optimizations:
    3.1 checking $this->_globalVar['action'] instead of $_GET['action'] as these two should be the same, and if i remember corret $_GET removes data upon first retrieaval so it might not exist here
    3.2 $tubeStats['pause-time-left'] would sometimes be missing when auto refreshing

This is my first set of contribution pr's, so please do say if i am missing anything or have forgotten to add something :)

example of the missing pause-time-left keys and statsTube missing: These errors are pr tube failing, which in our case is almost always every tube (around 40)
![image](https://github.com/user-attachments/assets/f9c21afd-854d-4611-9b9c-fb6e80a4559d)


