### PR TITLE
Implement Default UI Settings from config.php

### DIFF
--- a/config.php
+++ b/config.php
@@ -17,8 +17,30 @@ $GLOBALS['config'] = array(
         'username' => 'admin',
         'password' => 'password',
     ),
+
+    /**
+     * Default UI settings (used when no cookie is present).
+     * These values will be overridden by user-specific selection in Settings screen and kept in cookies.
+     * Keys use a positive 'enableFeature' convention where applicable.
+     * 'true' means the feature is ON by default.
+     * 'false' means the feature is OFF by default.
+     */
+    'settings' => array(
+        // Numeric settings
+        'tubePauseSeconds'          => -1,    // Default: -1 (uses beanstalkd default of 1 hour)
+        'autoRefreshTimeoutMs'      => 500,   // Default: 500ms interval for auto-refresh
+        'searchResultLimit'         => 25,    // Default: 25 results in search
+
+        // Boolean settings (true = enabled/checked by default)
+        'enableJsonDecode'          => true,  // Default: Job data IS json_decoded by default
+        'enableJobDataHighlight'    => true,  // Default: Job data highlighting IS enabled by default
+        'enableAutoRefreshLoad'     => false,  // Default: Auto-refresh IS disabled on page load
+        'enableUnserialization'     => false, // Default: Job data IS NOT unserialized by default
+        'enableBase64Decode'        => false, // Default: Job data IS NOT base64_decoded by default
+    ),
+
     /**
      * Version number
      */
-    'version' => '1.7.23',
+    'version' => '1.8.0', // Consider updating if you modify core functionality
 );

--- a/lib/tpl/currentTubeJobs.php
+++ b/lib/tpl/currentTubeJobs.php
@@ -6,9 +6,8 @@ $visible = $console->getTubeStatVisible();
 $sampleJobs = $console->getSampleJobs($tube);
 $allStats = $console->getTubeStatValues($tube);
 
-if (!@empty($_COOKIE['tubePauseSeconds'])) {
-    $tubePauseSeconds = intval($_COOKIE['tubePauseSeconds']);
-} else {
+$tubePauseSeconds = $settings->getTubePauseSeconds();
+if ($tubePauseSeconds === -1) {
     $tubePauseSeconds = 3600;
 }
 

--- a/lib/tpl/currentTubeJobsActionsRow.php
+++ b/lib/tpl/currentTubeJobsActionsRow.php
@@ -2,9 +2,8 @@
 $sampleJobs = $console->getSampleJobs($tube);
 $buriedJobsCount = $allStats['current-jobs-buried'];
 
-if (!@empty($_COOKIE['tubePauseSeconds'])) {
-    $tubePauseSeconds = intval($_COOKIE['tubePauseSeconds']);
-} else {
+$tubePauseSeconds = $settings->getTubePauseSeconds();
+if ($tubePauseSeconds === -1) {
     $tubePauseSeconds = 3600;
 }
 ?>
@@ -18,22 +17,22 @@ if (!@empty($_COOKIE['tubePauseSeconds'])) {
             <input type="hidden" name="server" value="<?php echo $server ?>">
             <input type="hidden" name="tube" value="<?php echo urlencode($tube) ?>">
             <input type="hidden" name="action" value="kick">
-            <input id="kick_tube_no_<?php echo md5($tube);?>" type="number" value="10" name="count" min="0" step="1" size="4" class="btn btn-default btn-sm kick_jobs_no">
+            <input id="kick_tube_no_<?php echo md5($tube); ?>" type="number" value="10" name="count" min="0" step="1" size="4" class="btn btn-default btn-sm kick_jobs_no">
         </div>
     </form>
 
-    <a class="btn btn-default btn-sm" href="./?server=<?php echo $server ?>&tube=<?php echo urlencode($tube) ?>&action=kick&count=<?=$buriedJobsCount?>"><i class="glyphicon glyphicon-forward"></i> Kick all jobs</a>
+    <a class="btn btn-default btn-sm" href="./?server=<?php echo $server ?>&tube=<?php echo urlencode($tube) ?>&action=kick&count=<?= $buriedJobsCount ?>"><i class="glyphicon glyphicon-forward"></i> Kick all jobs</a>
 
     <?php
     if (empty($tubeStats['pause-time-left'])) {
-        ?><a class="btn btn-default btn-sm" href="./?server=<?php echo $server ?>&tube=<?php echo urlencode($tube) ?>&action=pause&count=-1"
-           title="Temporarily prevent jobs being reserved from the given tube. Pause for: <?php echo $tubePauseSeconds; ?> seconds"><i class="glyphicon glyphicon-pause"></i>
+    ?><a class="btn btn-default btn-sm" href="./?server=<?php echo $server ?>&tube=<?php echo urlencode($tube) ?>&action=pause&count=-1"
+            title="Temporarily prevent jobs being reserved from the given tube. Pause for: <?php echo $tubePauseSeconds; ?> seconds"><i class="glyphicon glyphicon-pause"></i>
             Pause tube</a><?php
-    } else {
-        ?><a class="btn btn-default btn-sm" href="./?server=<?php echo $server ?>&tube=<?php echo urlencode($tube) ?>&action=pause&count=0"
-           title="<?php echo sprintf('Pause seconds left: %d', $tubeStats['pause-time-left']); ?>"><i class="glyphicon glyphicon-play"></i> Unpause tube</a><?php
-       }
-       ?>
+                        } else {
+                            ?><a class="btn btn-default btn-sm" href="./?server=<?php echo $server ?>&tube=<?php echo urlencode($tube) ?>&action=pause&count=0"
+            title="<?php echo sprintf('Pause seconds left: %d', $tubeStats['pause-time-left']); ?>"><i class="glyphicon glyphicon-play"></i> Unpause tube</a><?php
+                                                                                                                                                            }
+                                                                                                                                                                ?>
     &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
     <div class="btn-group">
         <a data-toggle="modal" class="btn btn-success btn-sm" href="#" id="addJob"><i class="glyphicon glyphicon-plus-sign glyphicon-white"></i> Add job</a>
@@ -45,18 +44,18 @@ if (!@empty($_COOKIE['tubePauseSeconds'])) {
             <?php
             if (is_array($sampleJobs) && count($sampleJobs)) {
                 foreach ($sampleJobs as $key => $name) {
-                    ?>
+            ?>
                     <li>
                         <a href="./?server=<?php echo $server ?>&tube=<?php echo urlencode($tube) ?>&action=loadSample&key=<?php echo urlencode($key); ?>"><?php echo htmlspecialchars($name); ?></a>
                     </li>
-                    <?php
+                <?php
                 }
                 ?>
                 <li class="divider"></li>
                 <li><a href="./?action=manageSamples">Manage samples</a></li>
-                <?php
+            <?php
             } else {
-                ?>
+            ?>
                 <li>
                     <a href="#">There are no sample jobs</a>
                 </li>

--- a/lib/tpl/main.php
+++ b/lib/tpl/main.php
@@ -4,6 +4,8 @@ if ($server) {
     $serverKey = array_search($server, $servers);
     $serverLabel = is_numeric($serverKey) || empty($serverKey) ? $server : $serverKey;
 }
+$settings = new Settings();
+$jsDefaults = $settings->getAllDefaults();
 ?>
 <!DOCTYPE html>
 <html>
@@ -170,7 +172,7 @@ if ($server) {
                                 <input type="hidden" name="tube" value="<?php echo urlencode($tube); ?>" />
                                 <input type="hidden" name="state" value="<?php echo $state; ?>" />
                                 <input type="hidden" name="action" value="search" />
-                                <input type="hidden" name="limit" value="<?php echo empty($_COOKIE['searchResultLimit']) ? 25 : $_COOKIE['searchResultLimit']; ?>" />
+                                <input type="hidden" name="limit" value="<?php echo $settings->getSearchResultLimit() ?? 25 ?>" />
                                 <div class="form-group">
                                     <input type="text" class="form-control input-sm search-query" name="searchStr" placeholder="Search this tube">
                                 </div>
@@ -181,7 +183,7 @@ if ($server) {
                                 <input type="hidden" name="tube" value="<?php echo urlencode($tube); ?>" />
                                 <input type="hidden" name="state" value="<?php echo $state; ?>" />
                                 <input type="hidden" name="action" value="search" />
-                                <input type="hidden" name="limit" value="<?php echo empty($_COOKIE['searchResultLimit']) ? 25 : $_COOKIE['searchResultLimit']; ?>" />
+                                <input type="hidden" name="limit" value="<?php echo $settings->getSearchResultLimit() ?? 25 ?>" />
                                 <div class="form-group">
                                     <!-- Add a wrapper div for positioning -->
                                     <div class="search-wrapper" style="position: relative;">
@@ -250,11 +252,18 @@ if ($server) {
             <script src="js/jquery.cookie.js"></script>
             <script src="js/jquery.regexp.js"></script>
             <script src="assets/vendor/bootstrap/js/bootstrap.min.js"></script>
-            <?php if (isset($_COOKIE['isDisabledJobDataHighlight']) and $_COOKIE['isDisabledJobDataHighlight'] != 1) { ?>
+            <script>
+                // Use the defaults obtained from the Settings class instance
+                window.beanstalkConsoleDefaults = <?php echo json_encode($jsDefaults, JSON_PRETTY_PRINT); ?>;
+            </script>
+            <?php
+            if ($settings->isJobDataHighlightEnabled()) {
+            ?>
                 <script src="highlight/highlight.pack.js"></script>
                 <script>
                     hljs.initHighlightingOnLoad();
-                </script><?php } ?>
+                </script>
+            <?php } ?>
             <script src="js/customer.js"></script>
         </body>
 

--- a/lib/tpl/modalSettings.php
+++ b/lib/tpl/modalSettings.php
@@ -1,3 +1,10 @@
+<?php
+// Get default values directly from config for labels (provide fallbacks just in case)
+$configSettings = $GLOBALS['config']['settings'] ?? [];
+$defaultAutoRefreshTimeoutMs = $configSettings['autoRefreshTimeoutMs'] ?? 500;
+$defaultSearchResultLimit = $configSettings['searchResultLimit'] ?? 25;
+
+?>
 <div id="settings" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="settings-label" aria-hidden="true">
     <div class="modal-dialog">
         <div class="modal-content">
@@ -10,70 +17,50 @@
                     <div class="form-group">
                         <label for="tubePauseSeconds"><b>Tube pause seconds</b> (<i>-1</i> means the default: <i>3600</i>, <i>0</i> is reserved for
                             un-pause)</label>
-
-                        <input class="form-control focused" id="tubePauseSeconds" type="text" value="<?php
-                        if (@empty($_COOKIE['tubePauseSeconds']))
-                            echo -1;
-                        else
-                            echo @intval($_COOKIE['tubePauseSeconds']);
-                        ?>">
+                        <input class="form-control focused" id="tubePauseSeconds" name="tubePauseSeconds" type="text" value="<?php echo htmlspecialchars($settings->getTubePauseSeconds()); ?>">
                     </div>
                     <div class="form-group">
-                        <label for="focusedInput"><b>Auto-refresh interval in milliseconds</b> (Default: <i>500</i>)</label>
-                        <input class="form-control focused" id="autoRefreshTimeoutMs" type="text" value="<?php
-                        if (@empty($_COOKIE['autoRefreshTimeoutMs']))
-                            echo 500;
-                        else
-                            echo @intval($_COOKIE['autoRefreshTimeoutMs']);
-                        ?>">
+                        <label for="autoRefreshTimeoutMs"><b>Auto-refresh interval in milliseconds</b> (Default: <i><?php echo htmlspecialchars($defaultAutoRefreshTimeoutMs); ?></i>)</label>
+                        <input class="form-control focused" id="autoRefreshTimeoutMs" name="autoRefreshTimeoutMs" type="text" value="<?php echo htmlspecialchars($settings->getAutoRefreshTimeoutMs()); ?>">
                         <div class="checkbox">
                             <label>
-                                <input type="checkbox" id="isEnabledAutoRefreshLoad" value="0"
-                                       <?php if (@$_COOKIE['isEnabledAutoRefreshLoad'] == 1) { ?>checked="checked"<?php } ?>>
+                                <input type="checkbox" id="enableAutoRefreshLoad" name="enableAutoRefreshLoad" value="1" <?php if ($settings->isAutoRefreshLoadEnabled()) echo 'checked="checked"'; ?>>
                                 auto-refresh on load
                             </label>
                         </div>
                     </div>
                     <div class="form-group">
-                        <label for="focusedInput"><b>Search result limits</b> (Default: <i>25</i>)</label>
-                        <input class="form-control focused" id="searchResultLimit" type="text" value="<?php
-                        if (@empty($_COOKIE['searchResultLimit']))
-                            echo 25;
-                        else
-                            echo @intval($_COOKIE['searchResultLimit']);
-                        ?>">
+                        <label for="searchResultLimit"><b>Search result limits</b> (Default: <i><?php echo htmlspecialchars($defaultSearchResultLimit); ?></i>)</label>
+                        <input class="form-control focused" id="searchResultLimit" name="searchResultLimit" type="text" value="<?php echo htmlspecialchars($settings->getSearchResultLimit()); ?>">
                     </div>
                     <div class="form-group">
-                        <label for="focusedInput"><b>Preferred way to deal with job data</b></label>
+                        <label><b>Preferred way to deal with job data</b></label>
 
                         <div class="checkbox">
                             <label>
-                                <input type="checkbox" id="isDisabledJsonDecode" value="1"
-                                       <?php if (@$_COOKIE['isDisabledJsonDecode'] != 1) { ?>checked="checked"<?php } ?>>
+                                <!-- ID/Name now matches config/cookie key -->
+                                <input type="checkbox" id="enableJsonDecode" name="enableJsonDecode" value="1" <?php if ($settings->isJsonDecodeEnabled()) echo 'checked="checked"'; ?>>
                                 before display: json_decode()
                             </label>
                         </div>
 
                         <div class="checkbox">
                             <label>
-                                <input type="checkbox" id="isDisabledUnserialization" value="1"
-                                       <?php if (@$_COOKIE['isDisabledUnserialization'] != 1) { ?>checked="checked"<?php } ?>>
+                                <input type="checkbox" id="enableUnserialization" name="enableUnserialization" value="1" <?php if ($settings->isUnserializationEnabled()) echo 'checked="checked"'; ?>>
                                 before display: unserialize()
                             </label>
                         </div>
 
                         <div class="checkbox">
                             <label>
-                                <input type="checkbox" id="isEnabledBase64Decode" value="1"
-                                       <?php if (@$_COOKIE['isEnabledBase64Decode'] == 1) { ?>checked="checked"<?php } ?>>
+                                <input type="checkbox" id="enableBase64Decode" name="enableBase64Decode" value="1" <?php if ($settings->isBase64DecodeEnabled()) echo 'checked="checked"'; ?>>
                                 before display: base64_decode()
                             </label>
                         </div>
 
                         <div class="checkbox">
                             <label>
-                                <input type="checkbox" id="isDisabledJobDataHighlight" value="1"
-                                       <?php if (@$_COOKIE['isDisabledJobDataHighlight'] != 1) { ?>checked="checked"<?php } ?>>
+                                <input type="checkbox" id="enableJobDataHighlight" name="enableJobDataHighlight" value="1" <?php if ($settings->isJobDataHighlightEnabled()) echo 'checked="checked"'; ?>>
                                 after display: enable highlight
                             </label>
                         </div>

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -1,0 +1,131 @@
+<?php
+
+/**
+ * Class Settings
+ * Handles retrieving UI settings, prioritizing user cookies over config defaults.
+ * Assumes cookie names are identical to the keys defined in $GLOBALS['config']['settings'].
+ */
+class Settings
+{
+    /** @var array Associative array of default settings from config.php */
+    private $configDefaults = [];
+
+    /** @var array Associative array of user cookies */
+    private $cookies = [];
+
+    /**
+     * Constructor.
+     */
+    public function __construct()
+    {
+        // Ensure config is loaded globally or handle error/loading here if necessary
+        if (!isset($GLOBALS['config']['settings'])) {
+             $this->configDefaults = [];
+        } else {
+            $this->configDefaults = $GLOBALS['config']['settings'];
+        }
+
+        // Use $_COOKIE directly
+        $this->cookies = $_COOKIE;
+    }
+
+    /**
+     * Returns the raw default settings array as defined in config,
+     * with appropriate type casting for JS consumption.
+     * Useful for passing defaults to JavaScript.
+     *
+     * @return array
+     */
+    public function getAllDefaults(): array
+    {
+        $defaults = [];
+        foreach ($this->configDefaults as $key => $value) {
+            if (strpos($key, 'enable') === 0) { // Check if key starts with 'enable'
+                $defaults[$key] = (bool) $value;
+            } elseif (is_numeric($value)) { // Check if it's a numeric value
+                $defaults[$key] = (int) $value;
+            } else {
+                // Keep other types as they are (e.g., strings)
+                $defaults[$key] = $value;
+            }
+        }
+        return $defaults;
+    }
+
+    /**
+     * Gets the value for a numeric setting.
+     * Priority: Cookie > Config. Returns 0 if not found in either.
+     *
+     * @param string $key The key used in config and as the cookie name.
+     * @return int The setting value.
+     */
+    private function getNumericValue(string $key): int
+    {
+        if (isset($this->cookies[$key])) {
+            return intval($this->cookies[$key]);
+        }
+        // Fallback to config default, or 0 if not defined in config
+        return isset($this->configDefaults[$key]) ? (int)$this->configDefaults[$key] : 0;
+    }
+
+    /**
+     * Determines if a boolean feature should be enabled.
+     * Priority: Cookie > Config. Returns false if not found in either.
+     * Assumes cookie value '1' means enabled.
+     *
+     * @param string $key The key used in config and as the cookie name ('enable...').
+     * @return bool True if the feature should be considered enabled, false otherwise.
+     */
+    private function isFeatureEnabled(string $key): bool
+    {
+        if (isset($this->cookies[$key])) {
+            // Cookie value '1' means enabled
+            return ($this->cookies[$key] == 1);
+        }
+        // Fallback to config default, or false if not defined in config
+        return isset($this->configDefaults[$key]) ? (bool)$this->configDefaults[$key] : false;
+    }
+
+    // --- Public Getters for Specific Settings ---
+    // --- Uses the new unified config/cookie keys ---
+
+    public function getTubePauseSeconds(): int
+    {
+        return $this->getNumericValue('tubePauseSeconds');
+    }
+
+    public function getAutoRefreshTimeoutMs(): int
+    {
+        return $this->getNumericValue('autoRefreshTimeoutMs');
+    }
+
+    public function getSearchResultLimit(): int
+    {
+        return $this->getNumericValue('searchResultLimit');
+    }
+
+    public function isAutoRefreshLoadEnabled(): bool
+    {
+        return $this->isFeatureEnabled('enableAutoRefreshLoad');
+    }
+
+    public function isJsonDecodeEnabled(): bool
+    {
+        return $this->isFeatureEnabled('enableJsonDecode');
+    }
+
+    public function isUnserializationEnabled(): bool
+    {
+        return $this->isFeatureEnabled('enableUnserialization');
+    }
+
+    public function isBase64DecodeEnabled(): bool
+    {
+        return $this->isFeatureEnabled('enableBase64Decode');
+    }
+
+    public function isJobDataHighlightEnabled(): bool
+    {
+        return $this->isFeatureEnabled('enableJobDataHighlight');
+    }
+}


### PR DESCRIPTION
**Description:**

This pull request introduces a mechanism to define default values for UI settings (like auto-refresh, data decoding preferences, pause duration, etc.) within the `config.php` file. Previously, these settings relied solely on user-specific cookies, leading to inconsistent behavior on initial visits or after cookies were cleared.

Now, when a user accesses the console without existing preference cookies, the application will fall back to the defaults specified in the new `settings` array in `config.php`. User preferences saved via the Settings modal will still override these defaults and be stored in cookies.

**Key Changes:**

*   **`config.php`:** Added a new `settings` array to define default values for UI options. Standardized boolean keys to use the `enable...` convention (e.g., `enableAutoRefreshLoad`).
*   **`src/Settings.php`:** Created a new class to centralize the logic for retrieving settings. It prioritizes user cookies (`$_COOKIE`) over the defaults defined in `config.php`. Assumes cookie names now match config keys.
*   **`lib/include.php`:** Refactored the `Console` class to instantiate and use the `Settings` class. Passed the `Settings` instance to `BeanstalkInterface` and used it in `_actionPause`.
*   **`lib/BeanstalkInterface.class.php`:** Updated the constructor to accept the `Settings` object and modified `_decodeData` to use settings for enabling/disabling decoding options instead of directly accessing `$_COOKIE`.
*   **`lib/tpl/main.php`:** Instantiates the `Settings` class and uses its `getAllDefaults()` method to expose the default settings to JavaScript via a `window.beanstalkConsoleDefaults` object. Also updated highlight.js inclusion logic.
*   **`lib/tpl/modalSettings.php`:** Updated to use the `$settings` object (passed from `main.php`) to populate initial values. Changed input `id` and `name` attributes to match the new standardized config/cookie keys. Updated labels to show defaults from config.
*   **`lib/tpl/currentTubeJobs.php`:** Updated to use `$settings->getTubePauseSeconds()` instead of checking cookies or using hardcoded fallbacks.
*   **`public/js/customer.js`:**
    *   Added a `getSettingValue` helper function to check Cookie > `window.beanstalkConsoleDefaults` > Ultimate Fallback.
    *   Updated initial auto-refresh logic and the `reloader` function's timeout logic to use `getSettingValue`.
    *   Ensured the settings modal change handler saves cookies using the new standardized names matching the input IDs.

**Impact:**

*   Provides a consistent default experience for first-time users or users with cleared cookies.
*   Centralizes settings logic within the `Settings` class.
*   **Note:** Cookie names for boolean settings have changed (e.g., `isEnabledAutoRefreshLoad` is now `enableAutoRefreshLoad`). Existing user cookies using the old names will be ignored, and the new defaults will apply until the user re-saves their preferences via the Settings modal.

Fixes: #203