### PR TITLE
Implement Cache Busting for Static Assets (JS/CSS)

### DIFF
--- a/lib/tpl/main.php
+++ b/lib/tpl/main.php
@@ -22,9 +22,9 @@ $jsDefaults = $settings->getAllDefaults();
     </title>
 
     <!-- Bootstrap core CSS -->
-    <link href="assets/vendor/bootstrap/css/bootstrap.min.css" rel="stylesheet">
-    <link href="css/customer.css" rel="stylesheet">
-    <link href="highlight/styles/magula.css" rel="stylesheet">
+    <link href="assets/vendor/bootstrap/css/bootstrap.min.css?<?php echo $GLOBALS['config']['version'] ?>" rel="stylesheet">
+    <link href="css/customer.css?<?php echo $GLOBALS['config']['version'] ?>" rel="stylesheet">
+    <link href="highlight/styles/magula.css?<?php echo $GLOBALS['config']['version'] ?>" rel="stylesheet">
     <link rel="shortcut icon" href="assets/favicon.ico">
     <script>
         var url = "./?server=<?php echo $server ?>";
@@ -247,11 +247,11 @@ $jsDefaults = $settings->getAllDefaults();
                     <?php endif; ?>
             </div>
 
-            <script src='assets/vendor/jquery/jquery.js'></script>
-            <script src="js/jquery.color.js"></script>
-            <script src="js/jquery.cookie.js"></script>
-            <script src="js/jquery.regexp.js"></script>
-            <script src="assets/vendor/bootstrap/js/bootstrap.min.js"></script>
+            <script src='assets/vendor/jquery/jquery.js?<?php echo $GLOBALS['config']['version'] ?>'></script>
+            <script src="js/jquery.color.js?<?php echo $GLOBALS['config']['version'] ?>"></script>
+            <script src="js/jquery.cookie.js?<?php echo $GLOBALS['config']['version'] ?>"></script>
+            <script src="js/jquery.regexp.js?<?php echo $GLOBALS['config']['version'] ?>"></script>
+            <script src="assets/vendor/bootstrap/js/bootstrap.min.js?<?php echo $GLOBALS['config']['version'] ?>"></script>
             <script>
                 // Use the defaults obtained from the Settings class instance
                 window.beanstalkConsoleDefaults = <?php echo json_encode($jsDefaults, JSON_PRETTY_PRINT); ?>;
@@ -259,12 +259,12 @@ $jsDefaults = $settings->getAllDefaults();
             <?php
             if ($settings->isJobDataHighlightEnabled()) {
             ?>
-                <script src="highlight/highlight.pack.js"></script>
+                <script src="highlight/highlight.pack.js?<?php echo $GLOBALS['config']['version'] ?>"></script>
                 <script>
                     hljs.initHighlightingOnLoad();
                 </script>
             <?php } ?>
-            <script src="js/customer.js"></script>
+            <script src="js/customer.js?<?php echo $GLOBALS['config']['version'] ?>"></script>
         </body>
 
 </html>


### PR DESCRIPTION
**Problem:**

When upgrading beanstalk-console, browsers or intermediate caches (like CDNs) might continue serving outdated JavaScript (JS) and Cascading Style Sheets (CSS) files. This mismatch between the backend PHP code and the frontend assets can lead to a broken or malfunctioning user interface (UI).

**Solution:**

This change implements a standard cache-busting technique by appending the application's version number as a query parameter to all static asset URLs (`<link>` for CSS, `<script>` for JS) within the main HTML template (`lib/tpl/main.php`).

**How it Works:**

1.  The application version is defined in `config.php` within `$GLOBALS['config']['version']`.
2.  The `lib/tpl/main.php` template now accesses this version using `<?php echo $GLOBALS['config']['version'] ?>` and appends it as a query string (e.g., `?1.8.0`) to the `href` or `src` attribute of static asset includes.
3.  When the application is upgraded and the version number in `config.php` is updated, the URLs for all static assets change automatically.
4.  This change in URL forces browsers and caches to discard any previously cached versions and fetch the new files, ensuring the UI remains consistent with the application code after an upgrade.

**Files Changed:**

*   `lib/tpl/main.php`: Modified to append the version query parameter to CSS and JS includes.
*   `config.php`: (Implicitly relevant) Contains the `$GLOBALS['config']['version']` definition used for cache busting.

This resolves UI inconsistencies caused by stale asset caches during version upgrades.
