### PR TITLE
Fix missing version in config.php to prevent errors

### DIFF
--- a/config.php
+++ b/config.php
@@ -41,6 +41,10 @@ if (file_exists($localConfigFile) && is_readable($localConfigFile) && basename(_
 
 $GLOBALS['config'] = array(
     /**
+     * Version
+     */
+    'version' => '1.8.0',
+    /**
      * List of servers available for all users
      */
     'servers' => array(/* 'Local Beanstalkd' => 'beanstalk://localhost:11300', ... */),


### PR DESCRIPTION
## Summary

This update adds a missing version key to the config.php file used by beanstalk_console.

## Problem

When using beanstalk_console with the default config.php and without a config.local.php, the application:
	•	Throws errors related to a missing version.
	•	Fails to load stylesheets properly.

## Cause

The default config.php lacked a version key in the configuration array. This key is required for asset versioning and proper application behavior.

## Fix

Added a default version value to the config.php configuration array.

#Impact
	•	Prevents runtime errors due to missing version.
	•	Ensures stylesheets and other assets load correctly when no config.local.php is present.