### PR TITLE
Updated env var syntax

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM php:7.1-apache
 LABEL maintainer="Rion Dooley <dooley@tacc.utexas.edu>"
 
-ENV APACHE_DOCROOT "/var/www"
+ENV APACHE_DOCROOT="/var/www"
 
 RUN apt-get update
 RUN apt-get -y upgrade


### PR DESCRIPTION
A fix for the following Docker warning:

```
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 4)
 ```