### PR TITLE
Refactor version management: use BEANSTALK_CONSOLE_VERSION constant i…

### DIFF
--- a/config.php
+++ b/config.php
@@ -19,13 +19,11 @@
  * =============================================================================
  */
 
-$GLOBALS['config']['version'] = '1.8.0';
+define('BEANSTALK_CONSOLE_VERSION', '1.8.0');
 
 $localConfigFile = __DIR__ . '/config.local.php';
 if (file_exists($localConfigFile) && is_readable($localConfigFile) && basename(__FILE__) !== 'config.local.php') {
-    $temp_version = $GLOBALS['config']['version'];
     require $localConfigFile;
-    $GLOBALS['config']['version'] = $temp_version; // be on the safe side with the version number
     if (count($GLOBALS['config'], true) != 1 && count($GLOBALS['config'], true) < 16) {
         die('Please update your config.local.php with all new options. You are missing some.');
     }

--- a/lib/tpl/main.php
+++ b/lib/tpl/main.php
@@ -22,9 +22,9 @@ $jsDefaults = $settings->getAllDefaults();
     </title>
 
     <!-- Bootstrap core CSS -->
-    <link href="assets/vendor/bootstrap/css/bootstrap.min.css?<?php echo $GLOBALS['config']['version'] ?>" rel="stylesheet">
-    <link href="css/customer.css?<?php echo $GLOBALS['config']['version'] ?>" rel="stylesheet">
-    <link href="highlight/styles/magula.css?<?php echo $GLOBALS['config']['version'] ?>" rel="stylesheet">
+    <link href="assets/vendor/bootstrap/css/bootstrap.min.css?<?php echo BEANSTALK_CONSOLE_VERSION ?>" rel="stylesheet">
+    <link href="css/customer.css?<?php echo BEANSTALK_CONSOLE_VERSION ?>" rel="stylesheet">
+    <link href="highlight/styles/magula.css?<?php echo BEANSTALK_CONSOLE_VERSION ?>" rel="stylesheet">
     <link rel="shortcut icon" href="assets/favicon.ico">
     <script>
         var url = "./?server=<?php echo $server ?>";
@@ -247,11 +247,11 @@ $jsDefaults = $settings->getAllDefaults();
                     <?php endif; ?>
             </div>
 
-            <script src='assets/vendor/jquery/jquery.js?<?php echo $GLOBALS['config']['version'] ?>'></script>
-            <script src="js/jquery.color.js?<?php echo $GLOBALS['config']['version'] ?>"></script>
-            <script src="js/jquery.cookie.js?<?php echo $GLOBALS['config']['version'] ?>"></script>
-            <script src="js/jquery.regexp.js?<?php echo $GLOBALS['config']['version'] ?>"></script>
-            <script src="assets/vendor/bootstrap/js/bootstrap.min.js?<?php echo $GLOBALS['config']['version'] ?>"></script>
+            <script src='assets/vendor/jquery/jquery.js?<?php echo BEANSTALK_CONSOLE_VERSION ?>'></script>
+            <script src="js/jquery.color.js?<?php echo BEANSTALK_CONSOLE_VERSION ?>"></script>
+            <script src="js/jquery.cookie.js?<?php echo BEANSTALK_CONSOLE_VERSION ?>"></script>
+            <script src="js/jquery.regexp.js?<?php echo BEANSTALK_CONSOLE_VERSION ?>"></script>
+            <script src="assets/vendor/bootstrap/js/bootstrap.min.js?<?php echo BEANSTALK_CONSOLE_VERSION ?>"></script>
             <script>
                 // Use the defaults obtained from the Settings class instance
                 window.beanstalkConsoleDefaults = <?php echo json_encode($jsDefaults, JSON_PRETTY_PRINT); ?>;
@@ -259,12 +259,12 @@ $jsDefaults = $settings->getAllDefaults();
             <?php
             if ($settings->isJobDataHighlightEnabled()) {
             ?>
-                <script src="highlight/highlight.pack.js?<?php echo $GLOBALS['config']['version'] ?>"></script>
+                <script src="highlight/highlight.pack.js?<?php echo BEANSTALK_CONSOLE_VERSION ?>"></script>
                 <script>
                     hljs.initHighlightingOnLoad();
                 </script>
             <?php } ?>
-            <script src="js/customer.js?<?php echo $GLOBALS['config']['version'] ?>"></script>
+            <script src="js/customer.js?<?php echo BEANSTALK_CONSOLE_VERSION ?>"></script>
         </body>
 
 </html>

--- a/lib/tpl/serversList.php
+++ b/lib/tpl/serversList.php
@@ -126,7 +126,7 @@ if ($tplVars['_tplMain'] != 'ajax') {
         $document = json_decode($json, true);
         $latest = current($document);
         $version = @$latest['name'];
-        if (version_compare($version, $config['version']) > 0) {
+        if (version_compare($version, BEANSTALK_CONSOLE_VERSION) > 0) {
             ?>
             <br/>
             <div class="alert alert-info" style="position: relative;top:50px;">


### PR DESCRIPTION
This PR simplifies version management in the Beanstalk Console project:

- Removes the version from the `$GLOBALS['config']` array.
- Introduces a PHP constant `BEANSTALK_CONSOLE_VERSION` in config.php to hold the application version.
- Updates all references in the codebase to use the new constant instead of accessing the version from the config array.
- Reduces configuration complexity and prevents version duplication between config files and code.

This change makes version management more robust and easier to maintain, as the version is now defined in a single place and cannot be accidentally overridden or omitted in local configuration overrides. No functional changes to the application logic are introduced.

Fixes #209 
