### PR TITLE
Review batches upstream

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .vagrant
 nbproject/
 config.local.php
+review-batches/

--- a/README.md
+++ b/README.md
@@ -21,7 +21,16 @@
 - Search within job data fields
 - Move jobs between tubes
 - Pause tubes
+- Prepare review batches by moving jobs into an isolated review tube before moving, duplicating, or deleting them
 - Configurable UI settings (auto-refresh, decoding, pause duration, etc.)
+
+**Review batches**
+
+Review batches help inspect a bounded set of jobs without workers changing them during review. From a tube page, click "Prepare review batch", choose the source state, set how many current jobs to review, and choose the review tube name. Ready and delayed jobs can be reviewed when no clients are watching/waiting or when the tube is paused; the dialog can pause the tube and proceed when needed. Buried jobs can be reviewed directly because workers cannot reserve buried jobs.
+
+The review page uses a destination tube field, prefilled with the source tube. Moving jobs to the source tube returns them; changing the destination moves them elsewhere. Existing tubes are suggested, but new tube names can be typed. Selected jobs or all undecided jobs can also be duplicated to the destination or deleted from the review tube. Duplicated jobs remain available for further review actions until their review copy is moved or deleted. Job bodies can be snapshotted to local JSONL during preparation so they remain visible after review copies are moved or deleted.
+
+Review batch files are console-local support files used for auditing, current-state tracking, exports, and optional body display. They are not automatically removed, so delete completed review batches or disable body snapshots if disk growth is a concern.
 
 **Change log**
 

--- a/config.php
+++ b/config.php
@@ -95,7 +95,7 @@ $GLOBALS['config'] = array(
         // Dangerous: allow delayed job review even when workers may be watching. Requires explicit checkbox in the UI.
         'allowUnsafeDelayedOverride' => false,
         // If true, the UI never offers body snapshot capture and the backend refuses to create body snapshots.
-        // Body snapshots preserve review-time payloads, but can create large sensitive files and impact review-page/body-load performance.
+        // Body snapshots preserve review-time payloads, but can create large local files and impact review-page/body-load performance.
         'neverIncludeBodySnapshot' => false,
         // Directory for review metadata files. null means dirname($config['storage']) . '/review-batches'.
         // This stores audit JSONL, materialized current summaries, operation metadata, and optional body snapshot JSONL files.

--- a/config.php
+++ b/config.php
@@ -75,4 +75,30 @@ $GLOBALS['config'] = array(
         'enableUnserialization'     => false, // Default: Job data IS NOT unserialized by default
         'enableBase64Decode'        => false, // Default: Job data IS NOT base64_decoded by default
     ),
+
+    /**
+     * Review batch settings.
+     */
+    'review' => array(
+        // Enables the review batch UI and actions. Set false to disable this feature entirely.
+        'enabled' => false,
+        // Number of jobs processed per AJAX chunk while preparing reviews and while running chunked return/delete operations.
+        'chunkSize' => 200,
+        // Number of characters shown in the review table body preview before truncation.
+        'bodyPreviewLength' => 100,
+        // Allow preparing ready jobs only when stats-tube reports no watchers/waiters for the source tube.
+        'allowReadyWhenUnwatched' => true,
+        // Allow preparing delayed jobs only when stats-tube reports no watchers/waiters for the source tube.
+        'allowDelayedWhenUnwatched' => true,
+        // Dangerous: allow ready job review even when workers may be watching. Requires explicit checkbox in the UI.
+        'allowUnsafeReadyOverride' => false,
+        // Dangerous: allow delayed job review even when workers may be watching. Requires explicit checkbox in the UI.
+        'allowUnsafeDelayedOverride' => false,
+        // If true, the UI never offers body snapshot capture and the backend refuses to create body snapshots.
+        // Body snapshots preserve review-time payloads, but can create large sensitive files and impact review-page/body-load performance.
+        'neverIncludeBodySnapshot' => false,
+        // Directory for review metadata files. null means dirname($config['storage']) . '/review-batches'.
+        // This stores audit JSONL, materialized current summaries, operation metadata, and optional body snapshot JSONL files.
+        'storagePath' => null,
+    ),
 );

--- a/lib/include.php
+++ b/lib/include.php
@@ -480,6 +480,8 @@ class Console {
             'reviewBatchProcess',
             'reviewBatchReturnJobs',
             'reviewBatchDeleteJobs',
+            'reviewBatchMoveJobs',
+            'reviewBatchDuplicateJobs',
             'reviewBatchDownloadManifest',
             'reviewBatchDelete',
             'reviewBatchTakeOver',
@@ -829,6 +831,9 @@ class Console {
         $state = isset($_POST['state']) ? $_POST['state'] : 'buried';
         $tube = $this->_globalVar['tube'];
         $forceUnsafe = !empty($_POST['forceUnsafe']);
+        if (!empty($_POST['pauseAndProceed'])) {
+            $this->interface->pauseTube($tube, $this->getReviewPauseSeconds());
+        }
         $safety = $this->canPrepareReviewState($tube, $state, $forceUnsafe);
 
         if (!$safety['allowed']) {
@@ -838,12 +843,14 @@ class Console {
         }
 
         $tubeStats = $this->getTubeStatValues($tube);
-        $targetCount = $this->getStateCountFromStats($tubeStats, $state);
-        if ($targetCount <= 0) {
+        $stateCount = $this->getStateCountFromStats($tubeStats, $state);
+        if ($stateCount <= 0) {
             $_SESSION['error'] = 'The selected state has no jobs to review.';
             header(sprintf('Location: ./?server=%s&tube=%s', $this->_globalVar['server'], urlencode($tube)));
             exit();
         }
+        $targetCount = isset($_POST['reviewLimit']) ? max(1, (int)$_POST['reviewLimit']) : $stateCount;
+        $targetCount = min($targetCount, $stateCount);
         $createdAt = date('c');
         $id = 'review-' . date('Ymd-His') . '-' . preg_replace('/[^A-Za-z0-9_.-]/', '_', $tube) . '-' . mt_rand(1000, 9999);
         $reviewTube = isset($_POST['reviewTube']) && $_POST['reviewTube'] !== ''
@@ -861,6 +868,7 @@ class Console {
             'owner_ip' => $this->getRequestIp(),
             'status' => 'processing',
             'target_count' => $targetCount,
+            'source_state_count' => $stateCount,
             'processed' => 0,
             'errors' => 0,
             'force_unsafe' => $forceUnsafe ? 1 : 0,
@@ -971,6 +979,26 @@ class Console {
     }
 
     /**
+     * Moves selected review-copy jobs to the destination tube inline.
+     *
+     * @return void
+     * @throws InvalidArgumentException If the batch cannot be loaded or the operation cannot be recorded.
+     */
+    protected function _actionReviewBatchMoveJobs() {
+        $this->reviewBatchOperateJobs('move');
+    }
+
+    /**
+     * Duplicates selected review-copy jobs to the destination tube inline.
+     *
+     * @return void
+     * @throws InvalidArgumentException If the batch cannot be loaded or the operation cannot be recorded.
+     */
+    protected function _actionReviewBatchDuplicateJobs() {
+        $this->reviewBatchOperateJobs('duplicate');
+    }
+
+    /**
      * Downloads audit, summary, or body-snapshot export files for a review batch.
      *
      * @return void
@@ -1017,7 +1045,7 @@ class Console {
 
         foreach ($jobs as $manifestJob) {
             $status = isset($manifestJob['status']) ? $manifestJob['status'] : '';
-            if (in_array($status, array('returned', 'deleted'))) {
+            if (in_array($status, array('returned', 'deleted', 'moved_to_tube'), true)) {
                 continue;
             }
             if (empty($manifestJob['review_id'])) {
@@ -1043,7 +1071,7 @@ class Console {
     }
 
     /**
-     * Starts a chunked all-remaining return/delete operation for a review batch.
+     * Starts a chunked all-remaining review operation for a review batch.
      *
      * @return void
      * @throws InvalidArgumentException If the batch cannot be loaded, operation is invalid, or operation metadata cannot be saved.
@@ -1055,8 +1083,12 @@ class Console {
         $operationType = isset($_POST['operation']) ? $_POST['operation'] : '';
         $delay = isset($_POST['delay']) ? max(0, (int)$_POST['delay']) : 0;
 
-        if (!in_array($operationType, array('return_all_moved', 'delete_all_moved'))) {
+        if (!in_array($operationType, array('move_all_moved', 'duplicate_all_moved', 'delete_all_moved'), true)) {
             throw new InvalidArgumentException('Unsupported review operation');
+        }
+        $targetTube = isset($_POST['targetTube']) ? trim($_POST['targetTube']) : '';
+        if (in_array($operationType, array('move_all_moved', 'duplicate_all_moved'), true) && $targetTube === '') {
+            throw new InvalidArgumentException('Destination tube is required for move and duplicate operations');
         }
 
         $summary = $storage->getBatchSummary($batch['id'], 0, 0);
@@ -1067,6 +1099,7 @@ class Console {
             'batch_id' => $batch['id'],
             'operation' => $operationType,
             'delay' => $delay,
+            'target_tube' => $targetTube,
             'return_page' => isset($_POST['returnPage']) ? max(1, (int)$_POST['returnPage']) : 1,
             'per_page' => isset($_POST['perPage']) ? max(1, min(100, (int)$_POST['perPage'])) : 25,
             'mode' => 'all_moved',
@@ -1445,9 +1478,9 @@ class Console {
     }
 
     /**
-     * Runs the existing selected-row return/delete action for small manual selections.
+     * Runs the selected-row review action for small manual selections.
      *
-     * @param string $operation Operation name: return or delete.
+     * @param string $operation Operation name: move, duplicate, or delete.
      * @return void
      * @throws InvalidArgumentException If the batch cannot be loaded or the operation cannot be recorded.
      */
@@ -1460,6 +1493,22 @@ class Console {
         $selected = isset($_POST['job']) && is_array($_POST['job']) ? $_POST['job'] : array();
         $selectedJobs = $storage->getJobsByReviewIds($batch['id'], $selected);
         $delay = isset($_POST['delay']) ? max(0, (int)$_POST['delay']) : 0;
+        $targetTube = isset($_POST['targetTube']) ? trim($_POST['targetTube']) : '';
+        if ($operation === 'return' && $targetTube === '') {
+            $targetTube = $batch['source_tube'];
+        }
+        if (in_array($operation, array('move', 'duplicate'), true) && $targetTube === '') {
+            throw new InvalidArgumentException('Destination tube is required for move and duplicate operations');
+        }
+        $operationTypes = array(
+            'return' => 'move_all_moved',
+            'move' => 'move_all_moved',
+            'duplicate' => 'duplicate_all_moved',
+            'delete' => 'delete_all_moved',
+        );
+        if (!isset($operationTypes[$operation])) {
+            throw new InvalidArgumentException('Unsupported review operation');
+        }
 
         foreach ($selected as $reviewId) {
             $reviewId = (int)$reviewId;
@@ -1468,15 +1517,17 @@ class Console {
                 continue;
             }
             $status = isset($manifestJob['status']) ? $manifestJob['status'] : '';
-            $canReturn = $status === 'moved';
+            $canMoveOrDuplicate = in_array($status, array('moved', 'duplicated'), true);
             $canDelete = $status === 'moved' || $this->isReviewJobCleanupStatus($status);
-            if (($operation === 'return' && !$canReturn) || ($operation === 'delete' && !$canDelete)) {
+            if (($operation === 'delete' && !$canDelete)
+                    || (in_array($operation, array('return', 'move', 'duplicate'), true) && !$canMoveOrDuplicate)) {
                 continue;
             }
 
             $operationMeta = array(
-                'operation' => $operation === 'return' ? 'return_all_moved' : 'delete_all_moved',
+                'operation' => $operationTypes[$operation],
                 'delay' => $delay,
+                'target_tube' => $targetTube,
             );
             $service->operateReviewJob($batch, $manifestJob, $operationMeta);
         }
@@ -1607,11 +1658,20 @@ class Console {
      */
     public function getReviewOperationLabel($operation) {
         $operationType = isset($operation['operation']) ? $operation['operation'] : '';
-        if ($operationType === 'return_all_moved') {
+        if ($operationType === 'move_all_moved') {
+            if (isset($operation['target_tube']) && $operation['target_tube'] !== '') {
+                return 'moving jobs to ' . $operation['target_tube'];
+            }
             return 'returning jobs to the source tube';
         }
         if ($operationType === 'delete_all_moved') {
             return 'deleting review copies';
+        }
+        if ($operationType === 'duplicate_all_moved') {
+            if (isset($operation['target_tube']) && $operation['target_tube'] !== '') {
+                return 'duplicating jobs to ' . $operation['target_tube'];
+            }
+            return 'duplicating jobs to another tube';
         }
         return $operationType !== '' ? $operationType : 'a review operation';
     }
@@ -1666,6 +1726,8 @@ class Console {
             'original_id',
             'review_id',
             'returned_id',
+            'target_tube',
+            'target_id',
             'status',
             'pri',
             'age',
@@ -1680,6 +1742,7 @@ class Console {
             'buries',
             'kicks',
             'return_delay',
+            'target_delay',
             'error_message',
         );
 
@@ -1817,6 +1880,20 @@ class Console {
     }
 
     /**
+     * Returns the configured pause duration used by the review pause-and-proceed path.
+     *
+     * @return int Pause duration in seconds.
+     */
+    private function getReviewPauseSeconds() {
+        $settings = new Settings();
+        $settingValue = $settings->getTubePauseSeconds();
+        if ($settingValue == -1) {
+            return 3600;
+        }
+        return max(0, (int)$settingValue);
+    }
+
+    /**
      * Evaluates whether preparing the requested state is safe or explicitly allowed.
      *
      * @param string $tube Tube name.
@@ -1827,7 +1904,7 @@ class Console {
      */
     private function canPrepareReviewState($tube, $state, $forceUnsafe) {
         if ($state === 'buried') {
-            return array('allowed' => true, 'message' => 'Buried jobs are not reservable by workers.');
+            return array('allowed' => true, 'message' => 'Buried review can proceed because buried jobs are not reservable by workers.');
         }
 
         if ($state !== 'ready' && $state !== 'delayed') {
@@ -1837,24 +1914,32 @@ class Console {
         $stats = $this->getTubeStatValues($tube);
         $watching = isset($stats['current-watching']) ? (int)$stats['current-watching'] : 0;
         $waiting = isset($stats['current-waiting']) ? (int)$stats['current-waiting'] : 0;
+        $pauseTimeLeft = isset($stats['pause-time-left']) ? (int)$stats['pause-time-left'] : 0;
+        $safeBecausePaused = $pauseTimeLeft > 0;
 
         if ($state === 'ready') {
+            if ($safeBecausePaused) {
+                return array('allowed' => true, 'message' => 'Ready review is allowed because the tube is paused for ' . $pauseTimeLeft . ' more seconds.', 'watching' => $watching, 'waiting' => $waiting, 'pause_time_left' => $pauseTimeLeft);
+            }
             if ($watching === 0 && $waiting === 0 && $this->getReviewConfigBool('allowReadyWhenUnwatched', false)) {
-                return array('allowed' => true, 'message' => 'Ready review is allowed because there are no watchers or waiters.');
+                return array('allowed' => true, 'message' => 'Ready review is allowed because there are no watchers or waiters.', 'watching' => $watching, 'waiting' => $waiting, 'pause_time_left' => $pauseTimeLeft);
             }
             if ($forceUnsafe && $this->getReviewConfigBool('allowUnsafeReadyOverride', false)) {
-                return array('allowed' => true, 'message' => 'Unsafe ready review override is enabled.');
+                return array('allowed' => true, 'message' => 'Unsafe ready review override is enabled.', 'watching' => $watching, 'waiting' => $waiting, 'pause_time_left' => $pauseTimeLeft);
             }
-            return array('allowed' => false, 'message' => 'Ready jobs can only be reviewed when no clients are watching/waiting, unless unsafe ready override is enabled.');
+            return array('allowed' => false, 'message' => 'Ready jobs can only be reviewed when no clients are watching/waiting or the tube is paused, unless unsafe ready override is enabled.', 'watching' => $watching, 'waiting' => $waiting, 'pause_time_left' => $pauseTimeLeft);
         }
 
+        if ($safeBecausePaused) {
+            return array('allowed' => true, 'message' => 'Delayed review is allowed because the tube is paused for ' . $pauseTimeLeft . ' more seconds.', 'watching' => $watching, 'waiting' => $waiting, 'pause_time_left' => $pauseTimeLeft);
+        }
         if ($watching === 0 && $waiting === 0 && $this->getReviewConfigBool('allowDelayedWhenUnwatched', false)) {
-            return array('allowed' => true, 'message' => 'Delayed review is allowed because there are no watchers or waiters.');
+            return array('allowed' => true, 'message' => 'Delayed review is allowed because there are no watchers or waiters.', 'watching' => $watching, 'waiting' => $waiting, 'pause_time_left' => $pauseTimeLeft);
         }
         if ($forceUnsafe && $this->getReviewConfigBool('allowUnsafeDelayedOverride', false)) {
-            return array('allowed' => true, 'message' => 'Unsafe delayed review override is enabled.');
+            return array('allowed' => true, 'message' => 'Unsafe delayed review override is enabled.', 'watching' => $watching, 'waiting' => $waiting, 'pause_time_left' => $pauseTimeLeft);
         }
-        return array('allowed' => false, 'message' => 'Delayed jobs can only be reviewed when no clients are watching/waiting, unless unsafe delayed override is enabled.');
+        return array('allowed' => false, 'message' => 'Delayed jobs can only be reviewed when no clients are watching/waiting or the tube is paused, unless unsafe delayed override is enabled.', 'watching' => $watching, 'waiting' => $waiting, 'pause_time_left' => $pauseTimeLeft);
     }
 
     /**

--- a/lib/include.php
+++ b/lib/include.php
@@ -22,7 +22,11 @@ Pheanstalk_ClassLoader::register(dirname(__FILE__));
 require_once 'BeanstalkInterface.class.php';
 require_once dirname(__FILE__) . '/../config.php';
 require_once dirname(__FILE__) . '/../src/Storage.php';
+require_once dirname(__FILE__) . '/../src/ReviewBatchNaming.php';
+require_once dirname(__FILE__) . '/../src/ReviewBatchStorage.php';
+require_once dirname(__FILE__) . '/../src/ReviewBatchService.php';
 require_once dirname(__FILE__) . '/../src/Settings.php';
+require_once dirname(__FILE__) . '/../src/ReviewBatchPageBuilder.php';
 
 $GLOBALS['server'] = !empty($_GET['server']) ? filter_input(INPUT_GET, 'server', FILTER_SANITIZE_SPECIAL_CHARS) : '';
 $GLOBALS['action'] = !empty($_GET['action']) ? filter_input(INPUT_GET, 'action', FILTER_SANITIZE_SPECIAL_CHARS) : '';
@@ -45,6 +49,7 @@ class Console {
     private $serversEnv = array();
     private $serversCookie = array();
     private $searchResults = array();
+    private $reviewBatchPageBuilder = null;
     private $actionTimeStart = 0;
 
     public function __construct() {
@@ -200,6 +205,13 @@ class Console {
         }
     }
 
+    /**
+     * Returns stats-tube values, treating a vanished tube as empty.
+     *
+     * @param string $tube Tube name.
+     * @return array
+     * @throws Pheanstalk_Exception_ServerException If stats-tube fails for a reason other than NOT_FOUND.
+     */
     public function getTubeStatValues($tube) {
         // make sure, that rapid tube disappearance (eg: anonymous tubes, don't kill the interface, as they might be missing)
         try {
@@ -215,6 +227,18 @@ class Console {
 
     public function getSearchResult() {
         return $this->searchResults;
+    }
+
+    /**
+     * Returns whether review batch functionality is enabled by configuration.
+     *
+     * @return bool
+     */
+    public function isReviewEnabled() {
+        if (!isset($this->_globalVar['config']['review']['enabled'])) {
+            return false;
+        }
+        return (bool)$this->_globalVar['config']['review']['enabled'];
     }
 
     protected function __init() {
@@ -255,6 +279,17 @@ class Console {
             $storage = new Storage($GLOBALS['config']['storage']);
         } catch (Exception $ex) {
             $this->_errors[] = $ex->getMessage();
+        }
+        if ($this->isReviewEnabled()) {
+            try {
+                $reviewStorage = new ReviewBatchStorage($GLOBALS['config']);
+            } catch (Exception $ex) {
+                $this->_errors[] = $ex->getMessage();
+            }
+        }
+        if (isset($_SESSION['error'])) {
+            $this->_errors[] = $_SESSION['error'];
+            unset($_SESSION['error']);
         }
     }
 
@@ -337,6 +372,7 @@ class Console {
 
         if (!isset($_GET['server'])) {
             // execute methods without a server
+            // Refactor target: this dispatch block can eventually share dispatchAction().
             if (isset($_GET['action']) && in_array($_GET['action'], array('serversRemove', 'manageSamples', 'deleteSample', 'editSample', 'newSample'))) {
                 $funcName = "_action" . ucfirst($this->_globalVar['action']);
                 if (method_exists($this, $funcName)) {
@@ -350,13 +386,28 @@ class Console {
         try {
             $this->interface = new BeanstalkInterface($this->_globalVar['server']);
 
+            if (!empty($_GET['action']) && $this->shouldDispatchBeforeTubeStats($this->_globalVar['action'])) {
+                if ($this->isReviewJsonAction($this->_globalVar['action'])) {
+                    $this->dispatchJsonAction($this->_globalVar['action']);
+                    return;
+                }
+                if ($this->dispatchAction($this->_globalVar['action'])) {
+                    return;
+                }
+            }
+
             $this->_tplVars['tubes'] = $this->interface->getTubes();
 
             $stats = $this->interface->getTubesStats();
 
             $this->_tplVars['tubesStats'] = $stats;
-            $this->_tplVars['peek'] = $this->interface->peekAll($this->_globalVar['tube']);
+            // Only the default tube page renders the peek showcase; actions load their own data.
+            $this->_tplVars['peek'] = array();
+            if (empty($_GET['action']) && !empty($this->_globalVar['tube'])) {
+                $this->_tplVars['peek'] = $this->interface->peekAll($this->_globalVar['tube']);
+            }
             $this->_tplVars['contentType'] = $this->interface->getContentType();
+            // Refactor target: this dispatch block can eventually share dispatchAction().
             if (!empty($_GET['action'])) {
                 $funcName = "_action" . ucfirst($this->_globalVar['action']);
                 if (method_exists($this, $funcName)) {
@@ -374,6 +425,80 @@ class Console {
         } catch (Exception $e) {
             $this->_errors[] = $e->getMessage();
         }
+    }
+
+    /**
+     * Dispatches a normal page action when the target method exists.
+     *
+     * @param string $action Request action name.
+     * @return bool True when an action was handled.
+     * @throws Exception Propagates exceptions thrown by the dispatched action.
+     */
+    private function dispatchAction($action) {
+        $funcName = "_action" . ucfirst($action);
+        if (!method_exists($this, $funcName)) {
+            return false;
+        }
+        if (strpos($action, 'review') === 0 && !$this->isReviewEnabled()) {
+            $this->_errors[] = 'Review batches are disabled by config.';
+            return true;
+        }
+        $this->$funcName();
+        return true;
+    }
+
+    /**
+     * Dispatches a JSON action and converts uncaught exceptions to HTTP 500 JSON.
+     *
+     * @param string $action Request action name.
+     * @return void
+     */
+    private function dispatchJsonAction($action) {
+        try {
+            $funcName = "_action" . ucfirst($action);
+            if (!method_exists($this, $funcName)) {
+                $this->jsonResponse(array('result' => false, 'error' => 'Unsupported action'), 404);
+            }
+            if (strpos($action, 'review') === 0 && !$this->isReviewEnabled()) {
+                $this->jsonResponse(array('result' => false, 'error' => 'Review batches are disabled by config.'), 403);
+            }
+            $this->$funcName();
+        } catch (Exception $e) {
+            $this->jsonResponse(array('result' => false, 'error' => $e->getMessage()), 500);
+        }
+    }
+
+    /**
+     * Returns whether an action should run before normal tube stats are loaded.
+     *
+     * @param string $action Request action name.
+     * @return bool
+     */
+    private function shouldDispatchBeforeTubeStats($action) {
+        return in_array($action, array(
+            'reviewBatchStart',
+            'reviewBatchProcess',
+            'reviewBatchReturnJobs',
+            'reviewBatchDeleteJobs',
+            'reviewBatchDownloadManifest',
+            'reviewBatchDelete',
+            'reviewBatchTakeOver',
+            'reviewBatchOperationStart',
+            'reviewBatchOperationProcess',
+        ), true);
+    }
+
+    /**
+     * Returns whether a review action should be dispatched through JSON error handling.
+     *
+     * @param string $action Request action name.
+     * @return bool
+     */
+    private function isReviewJsonAction($action) {
+        return in_array($action, array(
+            'reviewBatchProcess',
+            'reviewBatchOperationProcess',
+        ), true);
     }
 
     protected function _actionKick() {
@@ -680,6 +805,467 @@ class Console {
         exit();
     }
 
+    /**
+     * Shows the list of review batches, optionally filtered to one source tube.
+     *
+     * @return void
+     */
+    protected function _actionReviewBatches() {
+        $this->_tplVars['_tplMain'] = 'main';
+        $this->_tplVars['_tplPage'] = 'reviewBatches';
+        $sourceTube = isset($_GET['sourceTube']) ? $_GET['sourceTube'] : null;
+        $this->_tplVars['reviewSourceTube'] = $sourceTube;
+        $this->_tplVars['reviewBatches'] = $this->getReviewBatches($sourceTube);
+    }
+
+    /**
+     * Creates a new review batch and redirects to the chunked preparation progress page.
+     *
+     * @return void
+     * @throws InvalidArgumentException If review storage cannot be created or initialized.
+     * @throws Pheanstalk_Exception_ServerException If tube safety stats fail unexpectedly.
+     */
+    protected function _actionReviewBatchStart() {
+        $state = isset($_POST['state']) ? $_POST['state'] : 'buried';
+        $tube = $this->_globalVar['tube'];
+        $forceUnsafe = !empty($_POST['forceUnsafe']);
+        $safety = $this->canPrepareReviewState($tube, $state, $forceUnsafe);
+
+        if (!$safety['allowed']) {
+            $_SESSION['error'] = $safety['message'];
+            header(sprintf('Location: ./?server=%s&tube=%s', $this->_globalVar['server'], urlencode($tube)));
+            exit();
+        }
+
+        $tubeStats = $this->getTubeStatValues($tube);
+        $targetCount = $this->getStateCountFromStats($tubeStats, $state);
+        if ($targetCount <= 0) {
+            $_SESSION['error'] = 'The selected state has no jobs to review.';
+            header(sprintf('Location: ./?server=%s&tube=%s', $this->_globalVar['server'], urlencode($tube)));
+            exit();
+        }
+        $createdAt = date('c');
+        $id = 'review-' . date('Ymd-His') . '-' . preg_replace('/[^A-Za-z0-9_.-]/', '_', $tube) . '-' . mt_rand(1000, 9999);
+        $reviewTube = isset($_POST['reviewTube']) && $_POST['reviewTube'] !== ''
+                ? $_POST['reviewTube']
+                : ReviewBatchNaming::defaultReviewTube($tube);
+
+        $batch = array(
+            'id' => $id,
+            'source_server' => $this->_globalVar['server'],
+            'source_tube' => $tube,
+            'source_state' => $state,
+            'review_tube' => $reviewTube,
+            'created_at' => $createdAt,
+            'owner_session_id' => $this->getReviewSessionId(),
+            'owner_ip' => $this->getRequestIp(),
+            'status' => 'processing',
+            'target_count' => $targetCount,
+            'processed' => 0,
+            'errors' => 0,
+            'force_unsafe' => $forceUnsafe ? 1 : 0,
+            'include_body_snapshot' => $this->shouldIncludeBodySnapshot() && !empty($_POST['includeBodySnapshot']) ? 1 : 0,
+            'safety_message' => $safety['message'],
+        );
+
+        $storage = $this->getReviewBatchStorage();
+        $storage->createBatch($batch);
+
+        header(sprintf('Location: ./?server=%s&action=reviewBatchProgress&batchId=%s', $this->_globalVar['server'], urlencode($id)));
+        exit();
+    }
+
+    /**
+     * Shows progress while jobs are copied to the review tube and removed from the source state.
+     *
+     * @return void
+     * @throws InvalidArgumentException If the batch cannot be loaded.
+     */
+    protected function _actionReviewBatchProgress() {
+        $batch = $this->loadReviewBatchFromRequest();
+        $storage = $this->getReviewBatchStorage();
+        $this->_tplVars['_tplMain'] = 'main';
+        $this->_tplVars['_tplPage'] = 'reviewBatchProgress';
+        $this->_tplVars['reviewBatch'] = $batch;
+        $this->_tplVars['reviewOperation'] = $storage->loadOperation($batch['id']);
+    }
+
+    /**
+     * Processes one preparation chunk for a review batch.
+     *
+     * @return void
+     * @throws InvalidArgumentException If the batch cannot be loaded or storage cannot record progress.
+     * @throws Pheanstalk_Exception_ServerException If tube safety stats fail unexpectedly.
+     */
+    protected function _actionReviewBatchProcess() {
+        $batch = $this->loadReviewBatchFromRequest();
+        $this->assertReviewBatchOwner($batch);
+        $storage = $this->getReviewBatchStorage();
+
+        if ($batch['status'] === 'complete' && (int)$batch['processed'] === 0 && (int)$batch['target_count'] > 0) {
+            $batch['status'] = 'processing';
+        }
+
+        if ($batch['status'] !== 'processing') {
+            $this->jsonResponse(array('result' => true, 'batch' => $batch));
+        }
+
+        $safety = $this->canPrepareReviewState($batch['source_tube'], $batch['source_state'], !empty($batch['force_unsafe']));
+        if (!$safety['allowed']) {
+            $batch['status'] = 'paused_safety_check_failed';
+            $batch['safety_message'] = $safety['message'];
+            $storage->saveBatch($batch);
+            $this->jsonResponse(array('result' => false, 'batch' => $batch, 'error' => $safety['message']));
+        }
+
+        $chunkSize = $this->getReviewConfigInt('chunkSize', 50);
+        if ($chunkSize < 1) {
+            $chunkSize = 50;
+        }
+
+        $service = new ReviewBatchService($this->interface, $storage);
+        $batch = $service->processPreparationChunk($batch, $chunkSize);
+        $this->jsonResponse(array('result' => $batch['status'] !== 'error', 'batch' => $batch));
+    }
+
+    /**
+     * Displays one review batch with paginated collapsed manifest rows.
+     *
+     * @return void
+     * @throws InvalidArgumentException If the batch cannot be loaded.
+     */
+    protected function _actionReviewBatchShow() {
+        $batch = $this->loadReviewBatchFromRequest();
+        $storage = $this->getReviewBatchStorage();
+        $page = isset($_GET['page']) ? max(1, (int)$_GET['page']) : 1;
+        $perPage = isset($_GET['perPage']) ? max(1, min(100, (int)$_GET['perPage'])) : 25;
+        $previewLength = $this->getReviewConfigInt('bodyPreviewLength', 100);
+        if ($previewLength < 1) {
+            $previewLength = 100;
+        }
+
+        $this->_tplVars['_tplMain'] = 'main';
+        $this->_tplVars['_tplPage'] = 'reviewBatchShow';
+        $pageBuilder = new ReviewBatchPageBuilder($this->interface, $storage);
+        $this->_tplVars = array_merge($this->_tplVars, $pageBuilder->buildShowPage($batch, $page, $perPage, $previewLength));
+    }
+
+    /**
+     * Returns selected review-copy jobs to the source tube inline.
+     *
+     * @return void
+     * @throws InvalidArgumentException If the batch cannot be loaded or the operation cannot be recorded.
+     */
+    protected function _actionReviewBatchReturnJobs() {
+        $this->reviewBatchOperateJobs('return');
+    }
+
+    /**
+     * Deletes selected review-copy jobs inline.
+     *
+     * @return void
+     * @throws InvalidArgumentException If the batch cannot be loaded or the operation cannot be recorded.
+     */
+    protected function _actionReviewBatchDeleteJobs() {
+        $this->reviewBatchOperateJobs('delete');
+    }
+
+    /**
+     * Downloads audit, summary, or body-snapshot export files for a review batch.
+     *
+     * @return void
+     * @throws InvalidArgumentException If the batch or requested export file cannot be read.
+     */
+    protected function _actionReviewBatchDownloadManifest() {
+        $batch = $this->loadReviewBatchFromRequest();
+        $format = isset($_GET['format']) ? $_GET['format'] : 'jsonl';
+        $storage = $this->getReviewBatchStorage();
+
+        if ($format === 'csv') {
+            $this->downloadReviewBatchCsv($batch, $storage);
+            return;
+        }
+        if ($format === 'body-snapshot') {
+            $this->downloadReviewBatchBodySnapshot($batch, $storage);
+            return;
+        }
+
+        $file = $storage->getJobsFile($batch['id']);
+        if (!is_file($file) || !is_readable($file)) {
+            throw new InvalidArgumentException('Review batch manifest not found');
+        }
+
+        header('Content-Type: application/x-ndjson');
+        header('Content-Disposition: attachment; filename="' . $batch['id'] . '.audit.jsonl"');
+        readfile($file);
+        exit();
+    }
+
+    /**
+     * Deletes a review batch, including remaining review-copy jobs and local files.
+     *
+     * @return void
+     * @throws InvalidArgumentException If the batch cannot be loaded or local files cannot be deleted.
+     */
+    protected function _actionReviewBatchDelete() {
+        $batch = $this->loadReviewBatchFromRequest();
+        $this->assertReviewBatchOwner($batch);
+        $storage = $this->getReviewBatchStorage();
+        $this->assertNoActiveReviewOperation($batch['id'], $storage);
+        $summary = $storage->getBatchSummary($batch['id']);
+        $jobs = $summary['jobs'];
+
+        foreach ($jobs as $manifestJob) {
+            $status = isset($manifestJob['status']) ? $manifestJob['status'] : '';
+            if (in_array($status, array('returned', 'deleted'))) {
+                continue;
+            }
+            if (empty($manifestJob['review_id'])) {
+                continue;
+            }
+            try {
+                $reviewJob = $this->interface->_client->peek((int)$manifestJob['review_id']);
+                if ($reviewJob) {
+                    $this->interface->_client->delete($reviewJob);
+                }
+            } catch (Exception $e) {
+                if (!$this->isBeanstalkNotFound($e)) {
+                    $_SESSION['error'] = 'Review batch was not deleted: ' . $e->getMessage();
+                    header('Location: ' . $this->reviewBatchShowUrl($batch['id']));
+                    exit();
+                }
+            }
+        }
+
+        $storage->deleteBatch($batch['id']);
+        header(sprintf('Location: ./?server=%s&action=reviewBatches', $this->_globalVar['server']));
+        exit();
+    }
+
+    /**
+     * Starts a chunked all-remaining return/delete operation for a review batch.
+     *
+     * @return void
+     * @throws InvalidArgumentException If the batch cannot be loaded, operation is invalid, or operation metadata cannot be saved.
+     */
+    protected function _actionReviewBatchOperationStart() {
+        $batch = $this->loadReviewBatchFromRequest();
+        $this->assertReviewBatchOwner($batch);
+        $storage = $this->getReviewBatchStorage();
+        $operationType = isset($_POST['operation']) ? $_POST['operation'] : '';
+        $delay = isset($_POST['delay']) ? max(0, (int)$_POST['delay']) : 0;
+
+        if (!in_array($operationType, array('return_all_moved', 'delete_all_moved'))) {
+            throw new InvalidArgumentException('Unsupported review operation');
+        }
+
+        $summary = $storage->getBatchSummary($batch['id'], 0, 0);
+        $targetCount = $summary['moved_count'];
+        $now = date('c');
+        $operation = array(
+            'id' => 'op-' . date('Ymd-His') . '-' . mt_rand(1000, 9999),
+            'batch_id' => $batch['id'],
+            'operation' => $operationType,
+            'delay' => $delay,
+            'return_page' => isset($_POST['returnPage']) ? max(1, (int)$_POST['returnPage']) : 1,
+            'per_page' => isset($_POST['perPage']) ? max(1, min(100, (int)$_POST['perPage'])) : 25,
+            'mode' => 'all_moved',
+            'status' => 'processing',
+            'processed' => 0,
+            'target_count' => $targetCount,
+            'errors' => 0,
+            'created_at' => $now,
+            'updated_at' => $now,
+            'owner_session_id' => $this->getReviewSessionId(),
+            'owner_ip' => $this->getRequestIp(),
+        );
+        $storage->startOperation($operation);
+
+        header(sprintf('Location: ./?server=%s&action=reviewBatchOperationProgress&batchId=%s', $this->_globalVar['server'], urlencode($batch['id'])));
+        exit();
+    }
+
+    /**
+     * Shows progress for a chunked all-remaining return/delete operation.
+     *
+     * @return void
+     * @throws InvalidArgumentException If the batch or operation metadata cannot be loaded.
+     */
+    protected function _actionReviewBatchOperationProgress() {
+        $batch = $this->loadReviewBatchFromRequest();
+        $operation = $this->loadReviewBatchOperation($batch['id']);
+
+        $this->_tplVars['_tplMain'] = 'main';
+        $this->_tplVars['_tplPage'] = 'reviewBatchOperationProgress';
+        $this->_tplVars['reviewBatch'] = $batch;
+        $this->_tplVars['reviewOperation'] = $operation;
+    }
+
+    /**
+     * Processes one chunk of a long-running review return/delete operation.
+     *
+     * @return void
+     * @throws InvalidArgumentException If the batch or operation cannot be loaded or progress cannot be recorded.
+     */
+    protected function _actionReviewBatchOperationProcess() {
+        $batch = $this->loadReviewBatchFromRequest();
+        $storage = $this->getReviewBatchStorage();
+        $operation = $this->loadReviewBatchOperation($batch['id']);
+        $this->assertReviewOperationOwner($operation);
+
+        if ($operation['status'] !== 'processing') {
+            $this->jsonResponse(array('result' => true, 'operation' => $operation));
+        }
+
+        $chunkSize = $this->getReviewConfigInt('chunkSize', 50);
+        if ($chunkSize < 1) {
+            $chunkSize = 50;
+        }
+
+        $jobs = $storage->getMovedJobs($batch['id'], $chunkSize);
+        if (!count($jobs)) {
+            $operation['status'] = 'complete';
+            $operation['target_count'] = (int)$operation['processed'];
+            $operation['updated_at'] = date('c');
+            $storage->saveOperation($operation);
+            $this->jsonResponse(array('result' => true, 'operation' => $operation));
+        }
+
+        $service = new ReviewBatchService($this->interface, $storage);
+        foreach ($jobs as $manifestJob) {
+            $result = $service->operateReviewJob($batch, $manifestJob, $operation);
+            $operation['processed'] = (int)$operation['processed'] + 1;
+            if (!$result) {
+                $operation['errors'] = (int)$operation['errors'] + 1;
+            }
+        }
+
+        $remaining = max(0, (int)$operation['target_count'] - (int)$operation['processed']);
+        if ($remaining === 0) {
+            $operation['status'] = 'complete';
+        }
+        $operation['updated_at'] = date('c');
+        $storage->saveOperation($operation);
+
+        $this->jsonResponse(array('result' => true, 'operation' => $operation, 'remaining' => $remaining));
+    }
+
+    /**
+     * Takes ownership of a stable review batch for the current session.
+     *
+     * @return void
+     * @throws InvalidArgumentException If the batch is processing or an operation is active.
+     */
+    protected function _actionReviewBatchTakeOver() {
+        $batch = $this->loadReviewBatchFromRequest();
+        $storage = $this->getReviewBatchStorage();
+        $operation = $storage->loadOperation($batch['id']);
+        $blockReason = $this->getReviewTakeOverBlockReason($batch, $operation);
+        if ($blockReason !== '') {
+            throw new InvalidArgumentException('Cannot take over yet because ' . $blockReason . '.');
+        }
+
+        $storage->takeOverBatch($batch['id'], $this->getReviewSessionId(), $this->getRequestIp());
+        header('Location: ' . $this->reviewBatchShowUrl($batch['id']));
+        exit();
+    }
+
+    /**
+     * Returns stored review batches for the current server, optionally filtered by source tube.
+     *
+     * @param string|null $sourceTube Source tube filter.
+     * @return array
+     * @throws InvalidArgumentException If review storage is unavailable.
+     */
+    public function getReviewBatches($sourceTube = null) {
+        if (!$this->isReviewEnabled()) {
+            return array();
+        }
+        $result = array();
+        $batches = $this->getReviewBatchStorage()->listBatches();
+        foreach ($batches as $batch) {
+            if (isset($batch['source_server']) && $batch['source_server'] === $this->_globalVar['server']) {
+                if ($sourceTube !== null && (!isset($batch['source_tube']) || $batch['source_tube'] !== $sourceTube)) {
+                    continue;
+                }
+                $result[] = $batch;
+            }
+        }
+        return $result;
+    }
+
+    /**
+     * Counts review batches associated with one source tube.
+     *
+     * @param string $tube Source tube name.
+     * @return int
+     * @throws InvalidArgumentException If review storage is unavailable.
+     */
+    public function countReviewBatchesForTube($tube) {
+        if (!$this->isReviewEnabled()) {
+            return 0;
+        }
+        return count($this->getReviewBatches($tube));
+    }
+
+    /**
+     * Returns whether the collapsed manifest row should still have a review-copy job to inspect.
+     *
+     * @param array $job Collapsed manifest row.
+     * @return bool
+     */
+    public function reviewJobHasInspectableCopy($job) {
+        return $this->getReviewBatchPageBuilder()->reviewJobHasInspectableCopy($job);
+    }
+
+    /**
+     * Returns whether the manifest status represents a leftover review copy needing cleanup.
+     *
+     * @param string $status Manifest status.
+     * @return bool
+     */
+    public function isReviewJobCleanupStatus($status) {
+        return $this->getReviewBatchPageBuilder()->isReviewJobCleanupStatus($status);
+    }
+
+    /**
+     * Formats a seconds value in the same days/hours/minutes/seconds style as job stats.
+     *
+     * @param int $value Duration in seconds.
+     * @return string
+     */
+    public function formatDuration($value) {
+        return $this->getReviewBatchPageBuilder()->formatDuration($value);
+    }
+
+    /**
+     * Returns whether a state can be prepared for review under current safety rules.
+     *
+     * @param string $tube Tube name.
+     * @param string $state Job state.
+     * @return array
+     * @throws Pheanstalk_Exception_ServerException If tube safety stats fail unexpectedly.
+     */
+    public function getReviewSafety($tube, $state) {
+        return $this->canPrepareReviewState($tube, $state, false);
+    }
+
+    /**
+     * Returns whether the configured unsafe override is available for a ready/delayed state.
+     *
+     * @param string $state Job state.
+     * @return bool
+     */
+    public function isUnsafeReviewOverrideEnabled($state) {
+        if ($state === 'ready') {
+            return $this->getReviewConfigBool('allowUnsafeReadyOverride', false);
+        }
+        if ($state === 'delayed') {
+            return $this->getReviewConfigBool('allowUnsafeDelayedOverride', false);
+        }
+        return false;
+    }
+
     protected function _actionMoveJobsTo() {
         $destServer = (isset($_GET['server'])) ? $_GET['server'] : null;
         $destTube = (isset($_GET['destTube'])) ? $_GET['destTube'] : null;
@@ -769,7 +1355,7 @@ class Console {
                     }
                 }
             } catch (Pheanstalk_Exception_ServerException $e) {
-                
+
             }
             if ($added >= $limit || (microtime(true) - $this->actionTimeStart) > $limit) {
                 break;
@@ -856,6 +1442,431 @@ class Console {
             // there might be no jobs to peek at, and peekReady raises exception in this situation
         }
         header(sprintf('Location: ./?server=%s&tube=%s', $server, urlencode($tube)));
+    }
+
+    /**
+     * Runs the existing selected-row return/delete action for small manual selections.
+     *
+     * @param string $operation Operation name: return or delete.
+     * @return void
+     * @throws InvalidArgumentException If the batch cannot be loaded or the operation cannot be recorded.
+     */
+    private function reviewBatchOperateJobs($operation) {
+        $batch = $this->loadReviewBatchFromRequest();
+        $this->assertReviewBatchOwner($batch);
+        $storage = $this->getReviewBatchStorage();
+        $service = new ReviewBatchService($this->interface, $storage);
+        $this->assertNoActiveReviewOperation($batch['id'], $storage);
+        $selected = isset($_POST['job']) && is_array($_POST['job']) ? $_POST['job'] : array();
+        $selectedJobs = $storage->getJobsByReviewIds($batch['id'], $selected);
+        $delay = isset($_POST['delay']) ? max(0, (int)$_POST['delay']) : 0;
+
+        foreach ($selected as $reviewId) {
+            $reviewId = (int)$reviewId;
+            $manifestJob = isset($selectedJobs[$reviewId]) ? $selectedJobs[$reviewId] : false;
+            if (!$manifestJob || !isset($manifestJob['review_id'])) {
+                continue;
+            }
+            $status = isset($manifestJob['status']) ? $manifestJob['status'] : '';
+            $canReturn = $status === 'moved';
+            $canDelete = $status === 'moved' || $this->isReviewJobCleanupStatus($status);
+            if (($operation === 'return' && !$canReturn) || ($operation === 'delete' && !$canDelete)) {
+                continue;
+            }
+
+            $operationMeta = array(
+                'operation' => $operation === 'return' ? 'return_all_moved' : 'delete_all_moved',
+                'delay' => $delay,
+            );
+            $service->operateReviewJob($batch, $manifestJob, $operationMeta);
+        }
+
+        header('Location: ' . $this->reviewBatchShowUrl($batch['id']));
+        exit();
+    }
+
+    /**
+     * Loads the operation metadata for an in-progress chunked review operation.
+     *
+     * @param string $batchId Batch id.
+     * @return array
+     * @throws InvalidArgumentException If the operation metadata is missing or review storage is unavailable.
+     */
+    private function loadReviewBatchOperation($batchId) {
+        $operation = $this->getReviewBatchStorage()->loadOperation($batchId);
+        if (!$operation) {
+            throw new InvalidArgumentException('Review batch operation not found');
+        }
+        return $operation;
+    }
+
+    /**
+     * Blocks manual/batch actions while a long-running operation is active.
+     *
+     * @param string $batchId Batch id.
+     * @param ReviewBatchStorage $storage Review batch storage.
+     * @return void
+     * @throws InvalidArgumentException If an operation is already processing.
+     */
+    private function assertNoActiveReviewOperation($batchId, $storage) {
+        $operation = $storage->loadOperation($batchId);
+        if ($operation && isset($operation['status']) && $operation['status'] === 'processing') {
+            $owner = isset($operation['owner_ip']) ? $operation['owner_ip'] : 'another session';
+            throw new InvalidArgumentException('Review batch operation is already running by ' . $owner . '.');
+        }
+    }
+
+    /**
+     * Ensures only the session that prepared a batch can mutate it.
+     *
+     * @param array $batch Review batch metadata.
+     * @return void
+     * @throws InvalidArgumentException If another session owns the batch.
+     */
+    private function assertReviewBatchOwner($batch) {
+        if ($this->isReviewOwnedByAnotherSession($batch)) {
+            throw new InvalidArgumentException('Review batch was prepared by ' . $this->getReviewOwnerIp($batch) . '.');
+        }
+    }
+
+    /**
+     * Ensures only the session that started an operation can continue polling it.
+     *
+     * @param array $operation Operation metadata.
+     * @return void
+     * @throws InvalidArgumentException If another session owns the active operation.
+     */
+    private function assertReviewOperationOwner($operation) {
+        if (isset($operation['status']) && $operation['status'] === 'processing'
+                && isset($operation['owner_session_id']) && $operation['owner_session_id'] !== $this->getReviewSessionId()) {
+            $owner = isset($operation['owner_ip']) ? $operation['owner_ip'] : 'another session';
+            throw new InvalidArgumentException('Review batch operation is already running by ' . $owner . '.');
+        }
+    }
+
+    /**
+     * Returns a stable id for the current PHP session.
+     *
+     * @return string
+     */
+    public function getReviewSessionId() {
+        return session_id();
+    }
+
+    /**
+     * Returns the request IP used in review ownership messages.
+     *
+     * @return string
+     */
+    public function getRequestIp() {
+        return isset($_SERVER['REMOTE_ADDR']) ? $_SERVER['REMOTE_ADDR'] : 'unknown IP';
+    }
+
+    /**
+     * Returns whether the current session differs from stored review ownership.
+     *
+     * @param array $record Batch or operation metadata.
+     * @return bool
+     */
+    public function isReviewOwnedByAnotherSession($record) {
+        return isset($record['owner_session_id']) && $record['owner_session_id'] !== '' && $record['owner_session_id'] !== $this->getReviewSessionId();
+    }
+
+    /**
+     * Returns a displayable owner IP for review ownership warnings.
+     *
+     * @param array $record Batch or operation metadata.
+     * @return string
+     */
+    public function getReviewOwnerIp($record) {
+        return isset($record['owner_ip']) && $record['owner_ip'] !== '' ? $record['owner_ip'] : 'unknown IP';
+    }
+
+    /**
+     * Returns why ownership cannot be taken over, or an empty string when takeover is allowed.
+     *
+     * @param array $batch Review batch metadata.
+     * @param array|false $operation Active operation metadata, if any.
+     * @return string
+     */
+    public function getReviewTakeOverBlockReason($batch, $operation = false) {
+        if (isset($batch['status']) && $batch['status'] === 'processing') {
+            return 'preparation is in progress';
+        }
+        if ($operation && isset($operation['status']) && $operation['status'] === 'processing') {
+            return $this->getReviewOperationLabel($operation) . ' is in progress from ' . $this->getReviewOwnerIp($operation);
+        }
+        return '';
+    }
+
+    /**
+     * Returns a human-readable operation label.
+     *
+     * @param array $operation Operation metadata.
+     * @return string
+     */
+    public function getReviewOperationLabel($operation) {
+        $operationType = isset($operation['operation']) ? $operation['operation'] : '';
+        if ($operationType === 'return_all_moved') {
+            return 'returning jobs to the source tube';
+        }
+        if ($operationType === 'delete_all_moved') {
+            return 'deleting review copies';
+        }
+        return $operationType !== '' ? $operationType : 'a review operation';
+    }
+
+    /**
+     * Detects beanstalkd NOT_FOUND errors so missing review copies can be reconciled.
+     *
+     * @param Exception $e Queue exception.
+     * @return bool
+     */
+    private function isBeanstalkNotFound($e) {
+        return $this->getReviewBatchPageBuilder()->isBeanstalkNotFound($e);
+    }
+
+    /**
+     * Builds a review-batch URL that preserves pagination context.
+     *
+     * @param string $batchId Batch id.
+     * @param int|null $page Current page, or null to read from request context.
+     * @param int|null $perPage Current page size, or null to read from request context.
+     * @return string
+     */
+    private function reviewBatchShowUrl($batchId, $page = null, $perPage = null) {
+        if ($page === null && isset($_REQUEST['returnPage'])) {
+            $page = max(1, (int)$_REQUEST['returnPage']);
+        }
+        if ($perPage === null && isset($_REQUEST['perPage'])) {
+            $perPage = max(1, min(100, (int)$_REQUEST['perPage']));
+        }
+
+        $url = sprintf('./?server=%s&action=reviewBatchShow&batchId=%s', urlencode($this->_globalVar['server']), urlencode($batchId));
+        if ($page !== null) {
+            $url .= '&page=' . (int)$page;
+        }
+        if ($perPage !== null) {
+            $url .= '&perPage=' . (int)$perPage;
+        }
+        return $url;
+    }
+
+    /**
+     * Streams the current collapsed manifest summary as CSV.
+     *
+     * @param array $batch Review batch metadata.
+     * @param ReviewBatchStorage $storage Review batch storage.
+     * @return void
+     */
+    private function downloadReviewBatchCsv($batch, $storage) {
+        $summary = $storage->getBatchSummary($batch['id']);
+        $jobs = $summary['jobs'];
+        $fields = array(
+            'original_id',
+            'review_id',
+            'returned_id',
+            'status',
+            'pri',
+            'age',
+            'job_created_at',
+            'delay',
+            'ttr',
+            'time-left',
+            'file',
+            'reserves',
+            'timeouts',
+            'releases',
+            'buries',
+            'kicks',
+            'return_delay',
+            'error_message',
+        );
+
+        header('Content-Type: text/csv');
+        header('Content-Disposition: attachment; filename="' . $batch['id'] . '.current-summary.csv"');
+
+        $out = fopen('php://output', 'w');
+        fputcsv($out, $fields);
+        foreach ($jobs as $job) {
+            $row = array();
+            foreach ($fields as $field) {
+                $row[] = isset($job[$field]) ? $job[$field] : '';
+            }
+            fputcsv($out, $row);
+        }
+        fclose($out);
+        exit();
+    }
+
+    /**
+     * Streams the body snapshot captured during review preparation.
+     *
+     * @param array $batch Review batch metadata.
+     * @param ReviewBatchStorage $storage Review batch storage.
+     * @return void
+     * @throws InvalidArgumentException If the body snapshot cannot be read.
+     */
+    private function downloadReviewBatchBodySnapshot($batch, $storage) {
+        $file = $storage->getBodySnapshotFile($batch['id']);
+        if (empty($batch['include_body_snapshot']) || !is_file($file) || !is_readable($file)) {
+            throw new InvalidArgumentException('Review batch body snapshot not found');
+        }
+
+        header('Content-Type: application/x-ndjson');
+        header('Content-Disposition: attachment; filename="' . $batch['id'] . '.body-snapshot.jsonl"');
+        readfile($file);
+        exit();
+    }
+
+    /**
+     * Creates review storage after enforcing the feature enabled flag.
+     *
+     * @return ReviewBatchStorage
+     * @throws InvalidArgumentException If review is disabled or storage is unavailable.
+     */
+    private function getReviewBatchStorage() {
+        if (!$this->isReviewEnabled()) {
+            throw new InvalidArgumentException('Review batches are disabled by config.');
+        }
+        return new ReviewBatchStorage($this->_globalVar['config']);
+    }
+
+    /**
+     * Returns the review page/display helper.
+     *
+     * @return ReviewBatchPageBuilder
+     * @throws InvalidArgumentException If review storage is unavailable.
+     */
+    private function getReviewBatchPageBuilder() {
+        if ($this->reviewBatchPageBuilder === null) {
+            $this->reviewBatchPageBuilder = new ReviewBatchPageBuilder($this->interface, $this->getReviewBatchStorage());
+        }
+        return $this->reviewBatchPageBuilder;
+    }
+
+    /**
+     * Loads and validates a review batch referenced by the current request.
+     *
+     * @return array
+     * @throws InvalidArgumentException If the batch is missing, review storage is unavailable, or the batch belongs to another server.
+     */
+    private function loadReviewBatchFromRequest() {
+        $id = isset($_REQUEST['batchId']) ? $_REQUEST['batchId'] : '';
+        $batch = $this->getReviewBatchStorage()->loadBatch($id);
+        if (!$batch) {
+            throw new InvalidArgumentException('Review batch not found');
+        }
+        if (isset($batch['source_server']) && $batch['source_server'] !== $this->_globalVar['server']) {
+            throw new InvalidArgumentException('Review batch belongs to a different server');
+        }
+        return $batch;
+    }
+
+    /**
+     * Sends a JSON response and ends the request.
+     *
+     * @param array $response Response payload.
+     * @param int $statusCode HTTP status code.
+     * @return void
+     */
+    private function jsonResponse($response, $statusCode = 200) {
+        if ($statusCode !== 200) {
+            http_response_code($statusCode);
+        }
+        header('Content-Type: application/json');
+        echo json_encode($response);
+        exit();
+    }
+
+    /**
+     * Reads a boolean review config value with a fallback.
+     *
+     * @param string $key Review config key.
+     * @param bool $default Default value.
+     * @return bool
+     */
+    private function getReviewConfigBool($key, $default) {
+        if (isset($this->_globalVar['config']['review'][$key])) {
+            return (bool)$this->_globalVar['config']['review'][$key];
+        }
+        return $default;
+    }
+
+    /**
+     * Reads an integer review config value with a fallback.
+     *
+     * @param string $key Review config key.
+     * @param int $default Default value.
+     * @return int
+     */
+    private function getReviewConfigInt($key, $default) {
+        if (isset($this->_globalVar['config']['review'][$key])) {
+            return (int)$this->_globalVar['config']['review'][$key];
+        }
+        return $default;
+    }
+
+    /**
+     * Returns whether body snapshot capture is permitted by configuration.
+     *
+     * @return bool
+     */
+    private function shouldIncludeBodySnapshot() {
+        return empty($this->_globalVar['config']['review']['neverIncludeBodySnapshot']);
+    }
+
+    /**
+     * Evaluates whether preparing the requested state is safe or explicitly allowed.
+     *
+     * @param string $tube Tube name.
+     * @param string $state Job state.
+     * @param bool $forceUnsafe Whether the user requested the unsafe override.
+     * @return array
+     * @throws Pheanstalk_Exception_ServerException If tube safety stats fail unexpectedly.
+     */
+    private function canPrepareReviewState($tube, $state, $forceUnsafe) {
+        if ($state === 'buried') {
+            return array('allowed' => true, 'message' => 'Buried jobs are not reservable by workers.');
+        }
+
+        if ($state !== 'ready' && $state !== 'delayed') {
+            return array('allowed' => false, 'message' => 'Unsupported review state.');
+        }
+
+        $stats = $this->getTubeStatValues($tube);
+        $watching = isset($stats['current-watching']) ? (int)$stats['current-watching'] : 0;
+        $waiting = isset($stats['current-waiting']) ? (int)$stats['current-waiting'] : 0;
+
+        if ($state === 'ready') {
+            if ($watching === 0 && $waiting === 0 && $this->getReviewConfigBool('allowReadyWhenUnwatched', false)) {
+                return array('allowed' => true, 'message' => 'Ready review is allowed because there are no watchers or waiters.');
+            }
+            if ($forceUnsafe && $this->getReviewConfigBool('allowUnsafeReadyOverride', false)) {
+                return array('allowed' => true, 'message' => 'Unsafe ready review override is enabled.');
+            }
+            return array('allowed' => false, 'message' => 'Ready jobs can only be reviewed when no clients are watching/waiting, unless unsafe ready override is enabled.');
+        }
+
+        if ($watching === 0 && $waiting === 0 && $this->getReviewConfigBool('allowDelayedWhenUnwatched', false)) {
+            return array('allowed' => true, 'message' => 'Delayed review is allowed because there are no watchers or waiters.');
+        }
+        if ($forceUnsafe && $this->getReviewConfigBool('allowUnsafeDelayedOverride', false)) {
+            return array('allowed' => true, 'message' => 'Unsafe delayed review override is enabled.');
+        }
+        return array('allowed' => false, 'message' => 'Delayed jobs can only be reviewed when no clients are watching/waiting, unless unsafe delayed override is enabled.');
+    }
+
+    /**
+     * Extracts the current job count for a state from stats-tube output.
+     *
+     * @param array $stats stats-tube response.
+     * @param string $state Job state.
+     * @return int
+     */
+    private function getStateCountFromStats($stats, $state) {
+        $key = 'current-jobs-' . $state;
+        return isset($stats[$key]) ? (int)$stats[$key] : 0;
     }
 
 }

--- a/lib/tpl/currentTubeJobsActionsRow.php
+++ b/lib/tpl/currentTubeJobsActionsRow.php
@@ -1,6 +1,35 @@
 <?php
 $sampleJobs = $console->getSampleJobs($tube);
 $buriedJobsCount = isset($allStats['current-jobs-buried']) ? $allStats['current-jobs-buried'] : 0;
+$reviewEnabled = $console->isReviewEnabled();
+$reviewBatchCount = 0;
+$reviewError = null;
+$reviewSafety = array();
+$reviewSafetyError = null;
+$reviewOwnerIps = array();
+if ($reviewEnabled) {
+    try {
+        $reviewBatchesForTube = $console->getReviewBatches($tube);
+        $reviewBatchCount = count($reviewBatchesForTube);
+        foreach ($reviewBatchesForTube as $reviewBatchForTube) {
+            if ($console->isReviewOwnedByAnotherSession($reviewBatchForTube)) {
+                $reviewOwnerIps[$console->getReviewOwnerIp($reviewBatchForTube)] = true;
+            }
+        }
+    } catch (Exception $e) {
+        $reviewError = $e->getMessage();
+    }
+    try {
+        foreach (array('buried', 'delayed', 'ready') as $reviewState) {
+            $reviewSafety[$reviewState] = $console->getReviewSafety($tube, $reviewState);
+        }
+    } catch (Exception $e) {
+        $reviewSafetyError = $e->getMessage();
+    }
+}
+$readyJobsCount = isset($allStats['current-jobs-ready']) ? (int)$allStats['current-jobs-ready'] : 0;
+$delayedJobsCount = isset($allStats['current-jobs-delayed']) ? (int)$allStats['current-jobs-delayed'] : 0;
+$bodySnapshotDisabled = !empty($config['review']['neverIncludeBodySnapshot']);
 
 $tubePauseSeconds = $settings->getTubePauseSeconds();
 if ($tubePauseSeconds === -1) {
@@ -62,4 +91,78 @@ if ($tubePauseSeconds === -1) {
             <?php } ?>
         </ul>
     </div>
+    <?php if ($reviewEnabled && $reviewBatchCount > 0): ?>
+        <a class="btn btn-warning btn-sm" href="./?server=<?php echo urlencode($server); ?>&action=reviewBatches&sourceTube=<?php echo urlencode($tube); ?>"><i class="glyphicon glyphicon-list-alt glyphicon-white"></i> Reviews for this tube (<?php echo (int)$reviewBatchCount; ?>)</a>
+    <?php endif; ?>
+    <?php if ($reviewEnabled): ?>
+        <a data-toggle="modal" class="btn btn-info btn-sm" href="#reviewBatchStart"><i class="glyphicon glyphicon-eye-open glyphicon-white"></i> Prepare review batch</a>
+    <?php endif; ?>
+    <?php if ($reviewError): ?>
+        <span class="text-danger">Review batches unavailable: <?php echo htmlspecialchars($reviewError); ?></span>
+    <?php endif; ?>
 </section>
+
+<?php if ($reviewEnabled): ?>
+<div class="modal fade" id="reviewBatchStart" tabindex="-1" role="dialog" aria-labelledby="reviewBatchStartLabel" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <form method="POST" action="./?server=<?php echo urlencode($server); ?>&tube=<?php echo urlencode($tube); ?>&action=reviewBatchStart">
+                <div class="modal-header">
+                    <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
+                    <h4 class="modal-title" id="reviewBatchStartLabel">Prepare jobs for review</h4>
+                </div>
+                <div class="modal-body">
+                    <?php if (count($reviewOwnerIps)): ?>
+                        <p class="alert alert-warning">
+                            Existing review batches for this tube were prepared from <?php echo htmlspecialchars(implode(', ', array_keys($reviewOwnerIps))); ?>.
+                        </p>
+                    <?php endif; ?>
+                    <div class="form-group">
+                        <label for="reviewState">State</label>
+                        <select id="reviewState" name="state" class="form-control">
+                            <option value="buried" data-count="<?php echo (int)$buriedJobsCount; ?>">Buried (<?php echo (int)$buriedJobsCount; ?>)</option>
+                            <option value="delayed" data-count="<?php echo (int)$delayedJobsCount; ?>">Delayed (<?php echo (int)$delayedJobsCount; ?>)</option>
+                            <option value="ready" data-count="<?php echo (int)$readyJobsCount; ?>">Ready (<?php echo (int)$readyJobsCount; ?>)</option>
+                        </select>
+                    </div>
+                    <div class="form-group">
+                        <label for="reviewTube">Review tube</label>
+                        <input id="reviewTube" name="reviewTube" class="form-control" value="<?php echo htmlspecialchars(ReviewBatchNaming::defaultReviewTube($tube)); ?>">
+                    </div>
+                    <p class="help-block">The batch records the current job count for the selected state and processes up to that number of jobs. Jobs added later are left for a later batch when queue order allows.</p>
+                    <?php if (!$bodySnapshotDisabled): ?>
+                        <div class="checkbox">
+                            <label>
+                                <input type="checkbox" name="includeBodySnapshot" value="1" checked="checked">
+                                Write body snapshot JSONL during preparation
+                            </label>
+                            <p class="help-block">Stores each job body in a local body-snapshot file as it is reviewed. This preserves payloads after review copies are returned or deleted, but can create a large sensitive file and affect review-page/body-load performance.</p>
+                        </div>
+                    <?php endif; ?>
+                    <?php if ($reviewSafetyError): ?>
+                        <p class="text-danger">Review safety checks unavailable: <?php echo htmlspecialchars($reviewSafetyError); ?></p>
+                    <?php else: ?>
+                        <ul class="list-unstyled">
+                            <?php foreach ($reviewSafety as $reviewState => $reviewStateSafety): ?>
+                                <li><strong><?php echo ucfirst($reviewState); ?>:</strong> <?php echo htmlspecialchars($reviewStateSafety['message']); ?></li>
+                            <?php endforeach; ?>
+                        </ul>
+                    <?php endif; ?>
+                    <?php if ($console->isUnsafeReviewOverrideEnabled('ready') || $console->isUnsafeReviewOverrideEnabled('delayed')): ?>
+                        <div class="checkbox">
+                            <label>
+                                <input type="checkbox" name="forceUnsafe" value="1">
+                                Use configured unsafe override for ready/delayed jobs
+                            </label>
+                        </div>
+                    <?php endif; ?>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+                    <button type="submit" class="btn btn-info" id="reviewBatchStartSubmit">Start review batch</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+<?php endif; ?>

--- a/lib/tpl/currentTubeJobsActionsRow.php
+++ b/lib/tpl/currentTubeJobsActionsRow.php
@@ -29,6 +29,17 @@ if ($reviewEnabled) {
 }
 $readyJobsCount = isset($allStats['current-jobs-ready']) ? (int)$allStats['current-jobs-ready'] : 0;
 $delayedJobsCount = isset($allStats['current-jobs-delayed']) ? (int)$allStats['current-jobs-delayed'] : 0;
+$reviewStateCounts = array(
+    'buried' => (int)$buriedJobsCount,
+    'delayed' => $delayedJobsCount,
+    'ready' => $readyJobsCount,
+);
+$defaultReviewState = 'buried';
+foreach ($reviewStateCounts as $reviewState => $reviewStateCount) {
+    if ($reviewStateCount > $reviewStateCounts[$defaultReviewState]) {
+        $defaultReviewState = $reviewState;
+    }
+}
 $bodySnapshotDisabled = !empty($config['review']['neverIncludeBodySnapshot']);
 
 $tubePauseSeconds = $settings->getTubePauseSeconds();
@@ -117,31 +128,42 @@ if ($tubePauseSeconds === -1) {
                             Existing review batches for this tube were prepared from <?php echo htmlspecialchars(implode(', ', array_keys($reviewOwnerIps))); ?>.
                         </p>
                     <?php endif; ?>
-                    <div class="form-group">
+                    <div class="form-inline" style="margin-bottom: 10px;">
                         <label for="reviewState">State</label>
-                        <select id="reviewState" name="state" class="form-control">
-                            <option value="buried" data-count="<?php echo (int)$buriedJobsCount; ?>">Buried (<?php echo (int)$buriedJobsCount; ?>)</option>
-                            <option value="delayed" data-count="<?php echo (int)$delayedJobsCount; ?>">Delayed (<?php echo (int)$delayedJobsCount; ?>)</option>
-                            <option value="ready" data-count="<?php echo (int)$readyJobsCount; ?>">Ready (<?php echo (int)$readyJobsCount; ?>)</option>
+                        <select id="reviewState" name="state" class="form-control" style="margin-right: 15px;">
+                            <?php foreach (array('buried', 'delayed', 'ready') as $reviewState): ?>
+                                <?php $stateSafety = isset($reviewSafety[$reviewState]) ? $reviewSafety[$reviewState] : array('allowed' => false, 'message' => 'Safety check unavailable.'); ?>
+                                <option value="<?php echo $reviewState; ?>"
+                                        data-count="<?php echo (int)$reviewStateCounts[$reviewState]; ?>"
+                                        data-allowed="<?php echo !empty($stateSafety['allowed']) ? 1 : 0; ?>"
+                                        data-force-allowed="<?php echo $console->isUnsafeReviewOverrideEnabled($reviewState) ? 1 : 0; ?>"
+                                        data-message="<?php echo htmlspecialchars($stateSafety['message']); ?>"<?php echo $reviewState === $defaultReviewState ? ' selected="selected"' : ''; ?>>
+                                    <?php echo ucfirst($reviewState); ?> (<?php echo (int)$reviewStateCounts[$reviewState]; ?>)
+                                </option>
+                            <?php endforeach; ?>
                         </select>
+                        <label for="reviewLimit">Jobs to review</label>
+                        <input id="reviewLimit" name="reviewLimit" class="form-control" style="width: 100px;" type="number" min="1" step="1" value="<?php echo (int)$reviewStateCounts[$defaultReviewState]; ?>">
+                        <p class="help-block">Prefilled with the selected state's current count. Lower it to prepare a smaller batch.</p>
                     </div>
                     <div class="form-group">
                         <label for="reviewTube">Review tube</label>
                         <input id="reviewTube" name="reviewTube" class="form-control" value="<?php echo htmlspecialchars(ReviewBatchNaming::defaultReviewTube($tube)); ?>">
                     </div>
-                    <p class="help-block">The batch records the current job count for the selected state and processes up to that number of jobs. Jobs added later are left for a later batch when queue order allows.</p>
+                    <p class="help-block">The batch records the current job count for the selected state and processes up to the requested number of jobs. Jobs added later are left for a later batch when queue order allows.</p>
                     <?php if (!$bodySnapshotDisabled): ?>
                         <div class="checkbox">
                             <label>
                                 <input type="checkbox" name="includeBodySnapshot" value="1" checked="checked">
                                 Write body snapshot JSONL during preparation
                             </label>
-                            <p class="help-block">Stores each job body in a local body-snapshot file as it is reviewed. This preserves payloads after review copies are returned or deleted, but can create a large sensitive file and affect review-page/body-load performance.</p>
+                            <p class="help-block">Stores each job body in a local body-snapshot file as it is reviewed. This preserves payloads after review copies are returned or deleted, but can create a large local file and affect review-page/body-load performance.</p>
                         </div>
                     <?php endif; ?>
                     <?php if ($reviewSafetyError): ?>
                         <p class="text-danger">Review safety checks unavailable: <?php echo htmlspecialchars($reviewSafetyError); ?></p>
                     <?php else: ?>
+                        <p id="reviewSafetyMessage" class="alert alert-info"></p>
                         <ul class="list-unstyled">
                             <?php foreach ($reviewSafety as $reviewState => $reviewStateSafety): ?>
                                 <li><strong><?php echo ucfirst($reviewState); ?>:</strong> <?php echo htmlspecialchars($reviewStateSafety['message']); ?></li>
@@ -159,6 +181,9 @@ if ($tubePauseSeconds === -1) {
                 </div>
                 <div class="modal-footer">
                     <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+                    <button type="submit" class="btn btn-warning" id="reviewBatchPauseProceedSubmit" name="pauseAndProceed" value="1">
+                        Pause tube and proceed
+                    </button>
                     <button type="submit" class="btn btn-info" id="reviewBatchStartSubmit">Start review batch</button>
                 </div>
             </form>

--- a/lib/tpl/currentTubeJobsShowcase.php
+++ b/lib/tpl/currentTubeJobsShowcase.php
@@ -23,6 +23,7 @@
                                     <td><?php echo $key ?></td>
                                     <td>
                                         <?php
+                                        // Refactor target: this block can eventually share formatDuration().
                                         if (in_array($key, array('age', 'delay', 'time-left'), true)) {
                                             $days = floor($value / 86400);
                                             $hours = floor($value / 3600) % 24;

--- a/lib/tpl/main.php
+++ b/lib/tpl/main.php
@@ -139,6 +139,9 @@ $jsDefaults = $settings->getAllDefaults();
                                         <li><a href="#clear-tubes" role="button" data-toggle="modal">Clear multiple tubes</a></li>
                                     <?php } ?>
                                     <li><a href="./?action=manageSamples" role="button">Manage samples</a></li>
+                                    <?php if ($server && $console->isReviewEnabled()) { ?>
+                                        <li><a href="./?server=<?php echo urlencode($server); ?>&action=reviewBatches" role="button">Review batches</a></li>
+                                    <?php } ?>
                                     <li class="divider"></li>
                                     <li><a href="https://github.com/kr/beanstalkd">Beanstalk (github)</a></li>
                                     <li><a href="https://github.com/kr/beanstalkd/blob/master/doc/protocol.txt">Protocol Specification</a></li>
@@ -177,7 +180,8 @@ $jsDefaults = $settings->getAllDefaults();
                                     <input type="text" class="form-control input-sm search-query" name="searchStr" placeholder="Search this tube">
                                 </div>
                             </form>
-                        <?php } elseif (isset($server) && $server) { ?>
+                        <?php // Show global tube search only on the default server view, not custom pages. ?>
+                        <?php } elseif (isset($server) && $server && !isset($_tplPage)) { ?>
                             <form class="navbar-form navbar-right" style="margin-top:5px;margin-bottom:0px;" role="search" action="" method="get">
                                 <input type="hidden" name="server" value="<?php echo $server; ?>" />
                                 <input type="hidden" name="tube" value="<?php echo urlencode($tube); ?>" />

--- a/lib/tpl/reviewBatchOperationProgress.php
+++ b/lib/tpl/reviewBatchOperationProgress.php
@@ -1,0 +1,56 @@
+<?php
+$batch = $reviewBatch;
+$operation = $reviewOperation;
+$label = $operation['operation'] === 'return_all_moved' ? 'Returning jobs to source tube' : 'Deleting review copies';
+$ownedByAnotherSession = $console->isReviewOwnedByAnotherSession($operation);
+$takeOverBlockReason = $console->getReviewTakeOverBlockReason($batch, $operation);
+?>
+<h3><?php echo htmlspecialchars($label); ?></h3>
+<p>
+    <a href="./?server=<?php echo urlencode($server); ?>&action=reviewBatchShow&batchId=<?php echo urlencode($batch['id']); ?>">&lt;&lt; review batch</a>
+    |
+    <a href="./?server=<?php echo urlencode($server); ?>&tube=<?php echo urlencode($batch['source_tube']); ?>">&lt;&lt; source tube</a>
+</p>
+
+<?php if ($ownedByAnotherSession): ?>
+    <p class="alert alert-warning">
+        This review operation is running from <?php echo htmlspecialchars($console->getReviewOwnerIp($operation)); ?>.
+        Cannot take over yet because <?php echo htmlspecialchars($takeOverBlockReason); ?>.
+    </p>
+<?php endif; ?>
+
+<div id="reviewBatchOperationProgress"
+     data-batch-id="<?php echo $ownedByAnotherSession ? '' : htmlspecialchars($batch['id']); ?>"
+     data-show-url="./?server=<?php echo urlencode($server); ?>&action=reviewBatchShow&batchId=<?php echo urlencode($batch['id']); ?>&page=<?php echo isset($operation['return_page']) ? (int)$operation['return_page'] : 1; ?>&perPage=<?php echo isset($operation['per_page']) ? (int)$operation['per_page'] : 25; ?>">
+    <table class="table table-bordered table-condensed">
+        <tbody>
+            <tr>
+                <th>Source</th>
+                <td><?php echo htmlspecialchars($batch['source_tube']); ?> / <?php echo htmlspecialchars($batch['source_state']); ?></td>
+            </tr>
+            <tr>
+                <th>Operation</th>
+                <td><?php echo htmlspecialchars($operation['operation']); ?></td>
+            </tr>
+            <tr>
+                <th>Status</th>
+                <td id="reviewBatchOperationStatus"><?php echo htmlspecialchars($operation['status']); ?></td>
+            </tr>
+            <tr>
+                <th>Progress</th>
+                <td><span id="reviewBatchOperationProcessed"><?php echo (int)$operation['processed']; ?></span> / <span id="reviewBatchOperationTarget"><?php echo (int)$operation['target_count']; ?></span></td>
+            </tr>
+            <tr>
+                <th>Errors</th>
+                <td id="reviewBatchOperationErrors"><?php echo (int)$operation['errors']; ?></td>
+            </tr>
+        </tbody>
+    </table>
+
+    <div class="progress">
+        <?php $pct = !empty($operation['target_count']) ? min(100, floor(((int)$operation['processed'] / (int)$operation['target_count']) * 100)) : 100; ?>
+        <div id="reviewBatchOperationProgressBar" class="progress-bar" role="progressbar" style="width: <?php echo $pct; ?>%;"></div>
+    </div>
+
+    <p id="reviewBatchOperationMessage" class="text-muted"><?php echo $ownedByAnotherSession ? 'Operation is owned by another session.' : 'Processing automatically in chunks.'; ?></p>
+</div>

--- a/lib/tpl/reviewBatchOperationProgress.php
+++ b/lib/tpl/reviewBatchOperationProgress.php
@@ -1,7 +1,7 @@
 <?php
 $batch = $reviewBatch;
 $operation = $reviewOperation;
-$label = $operation['operation'] === 'return_all_moved' ? 'Returning jobs to source tube' : 'Deleting review copies';
+$label = ucfirst($console->getReviewOperationLabel($operation));
 $ownedByAnotherSession = $console->isReviewOwnedByAnotherSession($operation);
 $takeOverBlockReason = $console->getReviewTakeOverBlockReason($batch, $operation);
 ?>

--- a/lib/tpl/reviewBatchProgress.php
+++ b/lib/tpl/reviewBatchProgress.php
@@ -1,0 +1,63 @@
+<?php
+$batch = $reviewBatch;
+$operation = isset($reviewOperation) ? $reviewOperation : false;
+$ownedByAnotherSession = $console->isReviewOwnedByAnotherSession($batch);
+$takeOverBlockReason = $console->getReviewTakeOverBlockReason($batch, $operation);
+?>
+<h3>Preparing review batch</h3>
+<p>
+    <a href="./?server=<?php echo urlencode($server); ?>&action=reviewBatches">&lt;&lt; review batches</a>
+    |
+    <a href="./?server=<?php echo urlencode($server); ?>&tube=<?php echo urlencode($batch['source_tube']); ?>">&lt;&lt; source tube</a>
+</p>
+
+<?php if ($ownedByAnotherSession): ?>
+    <p class="alert alert-warning">
+        Be careful, this review batch was prepared by another session (visiting from <?php echo htmlspecialchars($console->getReviewOwnerIp($batch)); ?>).
+        <?php if ($takeOverBlockReason === ''): ?>
+            <a class="btn btn-xs btn-warning"
+               href="./?server=<?php echo urlencode($server); ?>&action=reviewBatchTakeOver&batchId=<?php echo urlencode($batch['id']); ?>"
+               onclick="return confirm('Take over this review batch from session visiting from <?php echo htmlspecialchars($console->getReviewOwnerIp($batch)); ?>?');">Take over this review batch</a>
+        <?php else: ?>
+            Cannot take over yet because <?php echo htmlspecialchars($takeOverBlockReason); ?>.
+        <?php endif; ?>
+    </p>
+<?php endif; ?>
+<?php if ($operation && isset($operation['status']) && $operation['status'] === 'processing' && $console->isReviewOwnedByAnotherSession($operation)): ?>
+    <p class="alert alert-warning">
+        A review operation is currently running from <?php echo htmlspecialchars($console->getReviewOwnerIp($operation)); ?>.
+    </p>
+<?php endif; ?>
+
+<div id="reviewBatchProgress"
+     data-batch-id="<?php echo $ownedByAnotherSession ? '' : htmlspecialchars($batch['id']); ?>"
+     data-show-url="./?server=<?php echo urlencode($server); ?>&action=reviewBatchShow&batchId=<?php echo urlencode($batch['id']); ?>">
+    <table class="table table-bordered table-condensed">
+        <tbody>
+            <tr>
+                <th>Source</th>
+                <td><?php echo htmlspecialchars($batch['source_tube']); ?> / <?php echo htmlspecialchars($batch['source_state']); ?></td>
+            </tr>
+            <tr>
+                <th>Review tube</th>
+                <td><?php echo htmlspecialchars($batch['review_tube']); ?></td>
+            </tr>
+            <tr>
+                <th>Status</th>
+                <td id="reviewBatchStatus"><?php echo htmlspecialchars($batch['status']); ?></td>
+            </tr>
+            <tr>
+                <th>Progress</th>
+                <td><span id="reviewBatchProcessed"><?php echo (int)$batch['processed']; ?></span> / <span id="reviewBatchTarget"><?php echo (int)$batch['target_count']; ?></span></td>
+            </tr>
+        </tbody>
+    </table>
+
+    <div class="progress">
+        <?php $pct = !empty($batch['target_count']) ? min(100, floor(((int)$batch['processed'] / (int)$batch['target_count']) * 100)) : 100; ?>
+        <div id="reviewBatchProgressBar" class="progress-bar" role="progressbar" style="width: <?php echo $pct; ?>%;"></div>
+    </div>
+
+    <p id="reviewBatchMessage" class="text-muted"><?php echo $ownedByAnotherSession ? 'Preparation is owned by another session.' : 'Processing automatically. The batch is limited to the job count recorded when it started.'; ?></p>
+    <p><a class="btn btn-default" href="./?server=<?php echo urlencode($server); ?>&action=reviewBatchShow&batchId=<?php echo urlencode($batch['id']); ?>">Open batch</a></p>
+</div>

--- a/lib/tpl/reviewBatchShow.php
+++ b/lib/tpl/reviewBatchShow.php
@@ -16,6 +16,11 @@ $ownedByAnotherSession = $console->isReviewOwnedByAnotherSession($batch);
 $takeOverBlockReason = $console->getReviewTakeOverBlockReason($batch, $operation);
 $pageActionDisabled = $pageSelectableCount === 0 || $ownedByAnotherSession ? ' disabled="disabled"' : '';
 $batchActionDisabled = $remainingMovedCount === 0 || $ownedByAnotherSession ? ' disabled="disabled"' : '';
+$targetTubeOptions = isset($tubes) && is_array($tubes) ? $tubes : array();
+if (!in_array($batch['source_tube'], $targetTubeOptions, true)) {
+    $targetTubeOptions[] = $batch['source_tube'];
+    sort($targetTubeOptions);
+}
 ?>
 <h3>Review batch</h3>
 <p>
@@ -107,33 +112,75 @@ $batchActionDisabled = $remainingMovedCount === 0 || $ownedByAnotherSession ? ' 
     <input type="hidden" name="perPage" value="<?php echo (int)$perPage; ?>">
     <input type="hidden" id="reviewRemainingMovedCount" value="<?php echo (int)$remainingMovedCount; ?>">
 
-    <div class="form-inline" style="margin-bottom: 10px;">
-        <label for="reviewReturnDelay">Return delay seconds</label>
-        <input id="reviewReturnDelay" class="form-control input-sm" type="number" min="0" step="1" name="delay" value="0">
-        <button type="submit" class="btn btn-sm btn-success"
-                data-requires-selection="1"
-                data-confirm="Return selected review jobs to the source tube?"
-                formaction="./?server=<?php echo urlencode($server); ?>&action=reviewBatchReturnJobs&batchId=<?php echo urlencode($batch['id']); ?>"<?php echo $pageActionDisabled; ?>>
-            Return selected to source tube
-        </button>
-        <button type="submit" class="btn btn-sm btn-danger"
-                data-requires-selection="1"
-                data-confirm="Delete selected review-copy jobs?"
-                formaction="./?server=<?php echo urlencode($server); ?>&action=reviewBatchDeleteJobs&batchId=<?php echo urlencode($batch['id']); ?>"<?php echo $pageActionDisabled; ?>>
-            Delete selected review copies
-        </button>
-        <button type="submit" name="operation" value="return_all_moved" class="btn btn-sm btn-success"
-                data-requires-moved="1"
-                data-confirm="Return all remaining moved review jobs to the source tube?"
-                formaction="./?server=<?php echo urlencode($server); ?>&action=reviewBatchOperationStart&batchId=<?php echo urlencode($batch['id']); ?>"<?php echo $batchActionDisabled; ?>>
-            Return all remaining moved jobs
-        </button>
-        <button type="submit" name="operation" value="delete_all_moved" class="btn btn-sm btn-danger"
-                data-requires-moved="1"
-                data-confirm="Delete all remaining moved review-copy jobs?"
-                formaction="./?server=<?php echo urlencode($server); ?>&action=reviewBatchOperationStart&batchId=<?php echo urlencode($batch['id']); ?>"<?php echo $batchActionDisabled; ?>>
-            Delete all remaining review copies
-        </button>
+    <div class="well well-sm" style="margin-bottom: 10px;">
+        <div class="form-inline" style="margin-bottom: 8px;">
+            <label for="reviewTargetTube" style="display: inline-block; width: 110px;">Destination tube</label>
+            <input id="reviewTargetTube" class="form-control input-sm" style="width: 300px;" type="text" name="targetTube" list="reviewTargetTubeList" value="<?php echo htmlspecialchars($batch['source_tube']); ?>">
+            <datalist id="reviewTargetTubeList">
+                <?php foreach ($targetTubeOptions as $targetTubeOption): ?>
+                    <option value="<?php echo htmlspecialchars($targetTubeOption); ?>"></option>
+                <?php endforeach; ?>
+            </datalist>
+            <span class="help-block" style="display: inline; margin-left: 8px;">
+                Source tube: <?php echo htmlspecialchars($batch['source_tube']); ?>. Type a new tube name or choose an existing one.
+            </span>
+        </div>
+        <div class="form-inline">
+            <label for="reviewReturnDelay" style="display: inline-block; width: 110px;">Delay seconds</label>
+            <input id="reviewReturnDelay" class="form-control input-sm" style="width: 95px;" type="number" min="0" step="1" name="delay" value="0">
+        </div>
+        <div class="row" style="margin-top: 10px;">
+            <div class="col-sm-6">
+                <strong>Selected jobs</strong>
+                <div style="margin-top: 5px;">
+                    <button type="submit" class="btn btn-sm btn-primary"
+                            data-requires-selection="1"
+                            data-requires-target="1"
+                            data-confirm="Move selected review jobs to the destination tube?"
+                            formaction="./?server=<?php echo urlencode($server); ?>&action=reviewBatchMoveJobs&batchId=<?php echo urlencode($batch['id']); ?>"<?php echo $pageActionDisabled; ?>>
+                        Move selected
+                    </button>
+                    <button type="submit" class="btn btn-sm btn-default"
+                            data-requires-selection="1"
+                            data-requires-target="1"
+                            data-confirm="Duplicate selected review jobs to the destination tube?"
+                            formaction="./?server=<?php echo urlencode($server); ?>&action=reviewBatchDuplicateJobs&batchId=<?php echo urlencode($batch['id']); ?>"<?php echo $pageActionDisabled; ?>>
+                        Duplicate selected
+                    </button>
+                    <button type="submit" class="btn btn-sm btn-danger"
+                            data-requires-selection="1"
+                            data-confirm="Delete selected review-copy jobs?"
+                            formaction="./?server=<?php echo urlencode($server); ?>&action=reviewBatchDeleteJobs&batchId=<?php echo urlencode($batch['id']); ?>"<?php echo $pageActionDisabled; ?>>
+                        Delete selected
+                    </button>
+                </div>
+            </div>
+            <div class="col-sm-6">
+                <strong>All undecided jobs</strong>
+                <div style="margin-top: 5px;">
+                    <button type="submit" name="operation" value="move_all_moved" class="btn btn-sm btn-primary"
+                            data-requires-moved="1"
+                            data-requires-target="1"
+                            data-confirm="Move all undecided review jobs to the destination tube?"
+                            formaction="./?server=<?php echo urlencode($server); ?>&action=reviewBatchOperationStart&batchId=<?php echo urlencode($batch['id']); ?>"<?php echo $batchActionDisabled; ?>>
+                        Move all
+                    </button>
+                    <button type="submit" name="operation" value="duplicate_all_moved" class="btn btn-sm btn-default"
+                            data-requires-moved="1"
+                            data-requires-target="1"
+                            data-confirm="Duplicate all undecided review jobs to the destination tube?"
+                            formaction="./?server=<?php echo urlencode($server); ?>&action=reviewBatchOperationStart&batchId=<?php echo urlencode($batch['id']); ?>"<?php echo $batchActionDisabled; ?>>
+                        Duplicate all
+                    </button>
+                    <button type="submit" name="operation" value="delete_all_moved" class="btn btn-sm btn-danger"
+                            data-requires-moved="1"
+                            data-confirm="Delete all undecided review-copy jobs?"
+                            formaction="./?server=<?php echo urlencode($server); ?>&action=reviewBatchOperationStart&batchId=<?php echo urlencode($batch['id']); ?>"<?php echo $batchActionDisabled; ?>>
+                        Delete all
+                    </button>
+                </div>
+            </div>
+        </div>
     </div>
 
     <table class="table table-striped table-bordered table-condensed" id="reviewJobsTable">
@@ -164,7 +211,7 @@ $batchActionDisabled = $remainingMovedCount === 0 || $ownedByAnotherSession ? ' 
                 <?php
                 $reviewId = isset($job['review_id']) ? (int)$job['review_id'] : 0;
                 $status = isset($job['status']) ? $job['status'] : '';
-                $selectable = $status === 'moved';
+                $selectable = in_array($status, array('moved', 'duplicated'), true);
                 $viewable = $console->reviewJobHasInspectableCopy($job);
                 $preview = isset($jobPreviews[$reviewId]) ? $jobPreviews[$reviewId] : '';
                 $bodyInfo = isset($jobBodies[$reviewId]) ? $jobBodies[$reviewId] : array();
@@ -209,6 +256,10 @@ $batchActionDisabled = $remainingMovedCount === 0 || $ownedByAnotherSession ? ' 
                             Returned to source tube<?php echo isset($job['returned_id']) ? ' as job ' . (int)$job['returned_id'] : ''; ?>.
                         <?php elseif ($status === 'deleted'): ?>
                             Review copy deleted.
+                        <?php elseif ($status === 'moved_to_tube'): ?>
+                            Moved to <?php echo isset($job['target_tube']) ? htmlspecialchars($job['target_tube']) : 'destination tube'; ?><?php echo isset($job['target_id']) ? ' as job ' . (int)$job['target_id'] : ''; ?>.
+                        <?php elseif ($status === 'duplicated'): ?>
+                            Duplicated to <?php echo isset($job['target_tube']) ? htmlspecialchars($job['target_tube']) : 'destination tube'; ?><?php echo isset($job['target_id']) ? ' as job ' . (int)$job['target_id'] : ''; ?>. Review copy remains.
                         <?php elseif ($status === 'error'): ?>
                             <span class="text-danger"><?php echo isset($job['error_message']) ? htmlspecialchars($job['error_message']) : 'Review preparation error'; ?></span>
                         <?php else: ?>
@@ -229,13 +280,24 @@ $batchActionDisabled = $remainingMovedCount === 0 || $ownedByAnotherSession ? ' 
                                     data-buries="<?php echo isset($job['buries']) ? (int)$job['buries'] : ''; ?>">
                                 View
                             </button>
+                            <?php if ($status === 'duplicated'): ?>
+                                <button type="submit"
+                                        class="btn btn-xs btn-default"
+                                        name="job[]"
+                                        value="<?php echo $reviewId; ?>"
+                                        data-requires-target="1"
+                                        data-confirm="Duplicate this review job to the destination tube again?"<?php echo $ownedByAnotherSession ? ' disabled="disabled"' : ''; ?>
+                                        formaction="./?server=<?php echo urlencode($server); ?>&action=reviewBatchDuplicateJobs&batchId=<?php echo urlencode($batch['id']); ?>">
+                                    Duplicate again
+                                </button>
+                            <?php endif; ?>
                             <?php if ($console->isReviewJobCleanupStatus($status)): ?>
                                 <button type="submit"
                                         class="btn btn-xs btn-danger"
                                         form="reviewSingleDeleteForm"
                                         name="job[]"
                                         value="<?php echo $reviewId; ?>"
-                                        data-confirm="Delete this review copy? The source job may already exist."<?php echo $ownedByAnotherSession ? ' disabled="disabled"' : ''; ?>>
+                                        data-confirm="Delete this review copy? This only removes the copy in the review tube."<?php echo $ownedByAnotherSession ? ' disabled="disabled"' : ''; ?>>
                                     Delete review copy
                                 </button>
                             <?php endif; ?>

--- a/lib/tpl/reviewBatchShow.php
+++ b/lib/tpl/reviewBatchShow.php
@@ -1,0 +1,291 @@
+<?php
+$batch = $reviewBatch;
+$operation = isset($reviewOperation) ? $reviewOperation : false;
+$jobs = isset($reviewJobs) ? $reviewJobs : array();
+$total = isset($reviewJobsTotal) ? (int)$reviewJobsTotal : 0;
+$page = isset($reviewPage) ? (int)$reviewPage : 1;
+$perPage = isset($reviewPerPage) ? (int)$reviewPerPage : 25;
+$pages = $perPage > 0 ? (int)max(1, ceil($total / $perPage)) : 1;
+$baseUrl = './?server=' . urlencode($server) . '&action=reviewBatchShow&batchId=' . urlencode($batch['id']) . '&perPage=' . $perPage;
+$remainingMovedCount = isset($reviewRemainingMovedCount) ? (int)$reviewRemainingMovedCount : 0;
+$pageSelectableCount = isset($reviewPageSelectableCount) ? (int)$reviewPageSelectableCount : 0;
+$pageBodyCount = isset($reviewPageBodyCount) ? (int)$reviewPageBodyCount : $pageSelectableCount;
+$jobPreviews = isset($reviewJobPreviews) ? $reviewJobPreviews : array();
+$jobBodies = isset($reviewJobBodies) ? $reviewJobBodies : array();
+$ownedByAnotherSession = $console->isReviewOwnedByAnotherSession($batch);
+$takeOverBlockReason = $console->getReviewTakeOverBlockReason($batch, $operation);
+$pageActionDisabled = $pageSelectableCount === 0 || $ownedByAnotherSession ? ' disabled="disabled"' : '';
+$batchActionDisabled = $remainingMovedCount === 0 || $ownedByAnotherSession ? ' disabled="disabled"' : '';
+?>
+<h3>Review batch</h3>
+<p>
+    <a href="./?server=<?php echo urlencode($server); ?>&action=reviewBatches">&lt;&lt; review batches</a>
+    |
+    <a href="./?server=<?php echo urlencode($server); ?>&tube=<?php echo urlencode($batch['source_tube']); ?>">&lt;&lt; source tube</a>
+    |
+    <a href="./?server=<?php echo urlencode($server); ?>">&lt;&lt; tubes</a>
+    |
+    <a class="text-danger"
+       href="./?server=<?php echo urlencode($server); ?>&action=reviewBatchDelete&batchId=<?php echo urlencode($batch['id']); ?>"
+       onclick="return confirm('Delete this review batch and any remaining review-copy jobs?');">delete review</a>
+</p>
+
+<?php if ($console->isReviewOwnedByAnotherSession($batch)): ?>
+    <p class="alert alert-warning">
+        Be careful, this review batch was prepared by another session (visiting from <?php echo htmlspecialchars($console->getReviewOwnerIp($batch)); ?>).
+        <?php if ($takeOverBlockReason === ''): ?>
+            <a class="btn btn-xs btn-warning"
+               href="./?server=<?php echo urlencode($server); ?>&action=reviewBatchTakeOver&batchId=<?php echo urlencode($batch['id']); ?>"
+               onclick="return confirm('Take over this review batch from session visiting from <?php echo htmlspecialchars($console->getReviewOwnerIp($batch)); ?>?');">Take over this review batch</a>
+        <?php else: ?>
+            Cannot take over yet because <?php echo htmlspecialchars($takeOverBlockReason); ?>.
+        <?php endif; ?>
+    </p>
+<?php endif; ?>
+<?php if ($operation && isset($operation['status']) && $operation['status'] === 'processing' && $console->isReviewOwnedByAnotherSession($operation)): ?>
+    <p class="alert alert-warning">
+        A review operation is currently running from <?php echo htmlspecialchars($console->getReviewOwnerIp($operation)); ?>.
+    </p>
+<?php endif; ?>
+
+<table class="table table-bordered table-condensed">
+    <tbody>
+        <tr>
+            <th>Source</th>
+            <td><?php echo htmlspecialchars($batch['source_tube']); ?> / <?php echo htmlspecialchars($batch['source_state']); ?></td>
+        </tr>
+        <tr>
+            <th>Review tube</th>
+            <td><?php echo htmlspecialchars($batch['review_tube']); ?></td>
+        </tr>
+        <tr>
+            <th>Status</th>
+            <td><?php echo htmlspecialchars($batch['status']); ?></td>
+        </tr>
+        <tr>
+            <th>Prepared</th>
+            <td><?php echo (int)$batch['processed']; ?> / <?php echo (int)$batch['target_count']; ?></td>
+        </tr>
+    </tbody>
+</table>
+
+<?php if (!empty($batch['error_message'])): ?>
+    <p class="alert alert-danger">
+        <strong>Review preparation stopped with an error.</strong>
+        <?php echo htmlspecialchars($batch['error_message']); ?>
+        Successfully moved jobs below can still be returned or deleted. Review copies from failed source cleanup can be inspected or deleted.
+    </p>
+<?php endif; ?>
+
+<?php if ($batch['status'] === 'complete' && (int)$batch['processed'] === 0 && (int)$batch['target_count'] > 0): ?>
+    <p class="alert alert-warning">
+        This batch has no prepared jobs. It can be resumed with the current processor.
+        <a class="btn btn-xs btn-warning" href="./?server=<?php echo urlencode($server); ?>&action=reviewBatchProgress&batchId=<?php echo urlencode($batch['id']); ?>">Resume preparation</a>
+    </p>
+<?php endif; ?>
+
+<p>
+    <a class="btn btn-sm btn-default" href="./?server=<?php echo urlencode($server); ?>&action=reviewBatchDownloadManifest&batchId=<?php echo urlencode($batch['id']); ?>&format=jsonl">Download audit log JSONL</a>
+    <a class="btn btn-sm btn-default" href="./?server=<?php echo urlencode($server); ?>&action=reviewBatchDownloadManifest&batchId=<?php echo urlencode($batch['id']); ?>&format=csv">Download current summary CSV</a>
+    <?php if (!empty($batch['include_body_snapshot'])): ?>
+        <a class="btn btn-sm btn-default" href="./?server=<?php echo urlencode($server); ?>&action=reviewBatchDownloadManifest&batchId=<?php echo urlencode($batch['id']); ?>&format=body-snapshot">Download body snapshot JSONL</a>
+    <?php endif; ?>
+    <?php if ($pageBodyCount > 0): ?>
+        <button type="button" class="btn btn-sm btn-default" id="reviewToggleBodies" data-expanded="0">Show full bodies on this page</button>
+    <?php endif; ?>
+</p>
+
+<form id="reviewSingleDeleteForm" method="POST" action="./?server=<?php echo urlencode($server); ?>&action=reviewBatchDeleteJobs&batchId=<?php echo urlencode($batch['id']); ?>">
+    <input type="hidden" name="batchId" value="<?php echo htmlspecialchars($batch['id']); ?>">
+    <input type="hidden" name="returnPage" value="<?php echo (int)$page; ?>">
+    <input type="hidden" name="perPage" value="<?php echo (int)$perPage; ?>">
+</form>
+
+<form method="POST">
+    <input type="hidden" name="batchId" value="<?php echo htmlspecialchars($batch['id']); ?>">
+    <input type="hidden" name="returnPage" value="<?php echo (int)$page; ?>">
+    <input type="hidden" name="perPage" value="<?php echo (int)$perPage; ?>">
+    <input type="hidden" id="reviewRemainingMovedCount" value="<?php echo (int)$remainingMovedCount; ?>">
+
+    <div class="form-inline" style="margin-bottom: 10px;">
+        <label for="reviewReturnDelay">Return delay seconds</label>
+        <input id="reviewReturnDelay" class="form-control input-sm" type="number" min="0" step="1" name="delay" value="0">
+        <button type="submit" class="btn btn-sm btn-success"
+                data-requires-selection="1"
+                data-confirm="Return selected review jobs to the source tube?"
+                formaction="./?server=<?php echo urlencode($server); ?>&action=reviewBatchReturnJobs&batchId=<?php echo urlencode($batch['id']); ?>"<?php echo $pageActionDisabled; ?>>
+            Return selected to source tube
+        </button>
+        <button type="submit" class="btn btn-sm btn-danger"
+                data-requires-selection="1"
+                data-confirm="Delete selected review-copy jobs?"
+                formaction="./?server=<?php echo urlencode($server); ?>&action=reviewBatchDeleteJobs&batchId=<?php echo urlencode($batch['id']); ?>"<?php echo $pageActionDisabled; ?>>
+            Delete selected review copies
+        </button>
+        <button type="submit" name="operation" value="return_all_moved" class="btn btn-sm btn-success"
+                data-requires-moved="1"
+                data-confirm="Return all remaining moved review jobs to the source tube?"
+                formaction="./?server=<?php echo urlencode($server); ?>&action=reviewBatchOperationStart&batchId=<?php echo urlencode($batch['id']); ?>"<?php echo $batchActionDisabled; ?>>
+            Return all remaining moved jobs
+        </button>
+        <button type="submit" name="operation" value="delete_all_moved" class="btn btn-sm btn-danger"
+                data-requires-moved="1"
+                data-confirm="Delete all remaining moved review-copy jobs?"
+                formaction="./?server=<?php echo urlencode($server); ?>&action=reviewBatchOperationStart&batchId=<?php echo urlencode($batch['id']); ?>"<?php echo $batchActionDisabled; ?>>
+            Delete all remaining review copies
+        </button>
+    </div>
+
+    <table class="table table-striped table-bordered table-condensed" id="reviewJobsTable">
+        <thead>
+            <tr>
+                <th>
+                    <?php if ($pageSelectableCount > 0): ?>
+                        <input type="checkbox" id="reviewSelectAll">
+                        <br>
+                        <button type="button" class="btn btn-xs btn-link" id="reviewSelectAllButton">all</button>
+                        <button type="button" class="btn btn-xs btn-link" id="reviewSelectNoneButton">none</button>
+                    <?php endif; ?>
+                </th>
+                <th>Original ID</th>
+                <th>Review ID</th>
+                <th>Status</th>
+                <th>Pri</th>
+                <th>TTR</th>
+                <th>Age</th>
+                <th>Reserves</th>
+                <th>Buries</th>
+                <th>Body preview</th>
+                <th></th>
+            </tr>
+        </thead>
+        <tbody>
+            <?php foreach ($jobs as $job): ?>
+                <?php
+                $reviewId = isset($job['review_id']) ? (int)$job['review_id'] : 0;
+                $status = isset($job['status']) ? $job['status'] : '';
+                $selectable = $status === 'moved';
+                $viewable = $console->reviewJobHasInspectableCopy($job);
+                $preview = isset($jobPreviews[$reviewId]) ? $jobPreviews[$reviewId] : '';
+                $bodyInfo = isset($jobBodies[$reviewId]) ? $jobBodies[$reviewId] : array();
+                $fullBody = isset($bodyInfo['body']) ? $bodyInfo['body'] : '';
+                $contentType = isset($bodyInfo['content_type']) ? $bodyInfo['content_type'] : 'text';
+                $bodySource = isset($bodyInfo['body_source']) ? $bodyInfo['body_source'] : '';
+                $ageTitle = '';
+                if (!empty($job['job_created_at'])) {
+                    $ageTitle = 'Created at ' . $job['job_created_at'];
+                } elseif (isset($job['event_at'], $job['age']) && $status === 'moved') {
+                    $createdAt = strtotime($job['event_at']) - (int)$job['age'];
+                    $ageTitle = 'Created at ' . date('c', $createdAt);
+                }
+                $rowClass = $console->isReviewJobCleanupStatus($status) ? ' class="warning"' : ($viewable ? '' : ' class="text-muted"');
+                ?>
+                <tr<?php echo $rowClass; ?>>
+                    <td>
+                        <?php if ($selectable && $reviewId): ?>
+                            <input type="checkbox" class="reviewJobCheckbox" name="job[]" value="<?php echo $reviewId; ?>">
+                        <?php endif; ?>
+                    </td>
+                    <td><?php echo isset($job['original_id']) ? (int)$job['original_id'] : ''; ?></td>
+                    <td><?php echo $reviewId; ?></td>
+                    <td><?php echo htmlspecialchars($status); ?></td>
+                    <td><?php echo isset($job['pri']) ? (int)$job['pri'] : ''; ?></td>
+                    <td><?php echo isset($job['ttr']) ? (int)$job['ttr'] : ''; ?></td>
+                    <td<?php echo $ageTitle !== '' ? ' title="' . htmlspecialchars($ageTitle) . '"' : ''; ?>><?php echo isset($job['age']) ? $console->formatDuration($job['age']) : ''; ?></td>
+                    <td><?php echo isset($job['reserves']) ? (int)$job['reserves'] : ''; ?></td>
+                    <td><?php echo isset($job['buries']) ? (int)$job['buries'] : ''; ?></td>
+                    <td>
+                        <?php if ($viewable): ?>
+                            <pre class="reviewJobBodyPreview"
+                                 data-review-id="<?php echo $reviewId; ?>"
+                                 data-preview="<?php echo htmlspecialchars($preview); ?>"
+                                 style="max-height: 140px; overflow: auto; white-space: pre-wrap; word-break: break-word;"><?php echo htmlspecialchars($preview); ?></pre>
+                            <pre class="reviewJobBodyFull"
+                                 data-review-id="<?php echo $reviewId; ?>"
+                                 data-content-type="<?php echo htmlspecialchars($contentType); ?>"
+                                 data-body-source="<?php echo htmlspecialchars($bodySource); ?>"
+                                 style="display: none;"><?php echo htmlspecialchars($fullBody); ?></pre>
+                        <?php elseif ($status === 'returned'): ?>
+                            Returned to source tube<?php echo isset($job['returned_id']) ? ' as job ' . (int)$job['returned_id'] : ''; ?>.
+                        <?php elseif ($status === 'deleted'): ?>
+                            Review copy deleted.
+                        <?php elseif ($status === 'error'): ?>
+                            <span class="text-danger"><?php echo isset($job['error_message']) ? htmlspecialchars($job['error_message']) : 'Review preparation error'; ?></span>
+                        <?php else: ?>
+                            <?php echo htmlspecialchars($status); ?>
+                        <?php endif; ?>
+                    </td>
+                    <td>
+                        <?php if ($viewable && $reviewId): ?>
+                            <button type="button"
+                                    class="btn btn-xs btn-info reviewJobView"
+                                    data-review-id="<?php echo $reviewId; ?>"
+                                    data-original-id="<?php echo isset($job['original_id']) ? (int)$job['original_id'] : ''; ?>"
+                                    data-status="<?php echo htmlspecialchars($status); ?>"
+                                    data-pri="<?php echo isset($job['pri']) ? (int)$job['pri'] : ''; ?>"
+                                    data-ttr="<?php echo isset($job['ttr']) ? (int)$job['ttr'] : ''; ?>"
+                                    data-age="<?php echo isset($job['age']) ? (int)$job['age'] : ''; ?>"
+                                    data-reserves="<?php echo isset($job['reserves']) ? (int)$job['reserves'] : ''; ?>"
+                                    data-buries="<?php echo isset($job['buries']) ? (int)$job['buries'] : ''; ?>">
+                                View
+                            </button>
+                            <?php if ($console->isReviewJobCleanupStatus($status)): ?>
+                                <button type="submit"
+                                        class="btn btn-xs btn-danger"
+                                        form="reviewSingleDeleteForm"
+                                        name="job[]"
+                                        value="<?php echo $reviewId; ?>"
+                                        data-confirm="Delete this review copy? The source job may already exist."<?php echo $ownedByAnotherSession ? ' disabled="disabled"' : ''; ?>>
+                                    Delete review copy
+                                </button>
+                            <?php endif; ?>
+                        <?php endif; ?>
+                    </td>
+                </tr>
+            <?php endforeach; ?>
+        </tbody>
+    </table>
+</form>
+
+<ul class="pagination">
+    <?php
+    $paginationItems = array();
+    for ($i = 1; $i <= $pages; $i++) {
+        if ($i === 1 || $i === $pages || abs($i - $page) <= 2) {
+            $paginationItems[] = $i;
+        }
+    }
+    $previousItem = 0;
+    foreach ($paginationItems as $paginationItem):
+        if ($previousItem && $paginationItem > $previousItem + 1):
+            ?>
+            <li class="disabled"><span>...</span></li>
+            <?php
+        endif;
+        $previousItem = $paginationItem;
+        ?>
+        <li class="<?php echo $paginationItem === $page ? 'active' : ''; ?>">
+            <a href="<?php echo $baseUrl; ?>&page=<?php echo $paginationItem; ?>"><?php echo $paginationItem; ?></a>
+        </li>
+    <?php endforeach; ?>
+</ul>
+
+<div class="modal fade" id="reviewJobBodyModal" tabindex="-1" role="dialog" aria-labelledby="reviewJobBodyLabel" aria-hidden="true">
+    <div class="modal-dialog modal-lg">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
+                <h4 class="modal-title" id="reviewJobBodyLabel">Review job body</h4>
+            </div>
+            <div class="modal-body">
+                <table class="table table-condensed table-bordered">
+                    <tbody id="reviewJobBodyStats"></tbody>
+                </table>
+                <pre style="max-height: 520px; overflow: auto; white-space: pre-wrap; word-break: break-word;"><code id="reviewJobBodyContent" style="white-space: pre-wrap; word-break: break-word;"></code></pre>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/lib/tpl/reviewBatches.php
+++ b/lib/tpl/reviewBatches.php
@@ -1,0 +1,55 @@
+<?php
+$batches = isset($reviewBatches) ? $reviewBatches : array();
+$sourceTube = isset($reviewSourceTube) ? $reviewSourceTube : null;
+?>
+<h3>Review batches<?php echo $sourceTube ? ' for ' . htmlspecialchars($sourceTube) : ''; ?></h3>
+<p>
+    <a href="./?server=<?php echo urlencode($server); ?>">&lt;&lt; back to tubes</a>
+    <?php if ($sourceTube): ?>
+        |
+        <a href="./?server=<?php echo urlencode($server); ?>&tube=<?php echo urlencode($sourceTube); ?>">&lt;&lt; back to tube</a>
+        |
+        <a href="./?server=<?php echo urlencode($server); ?>&action=reviewBatches">show all review batches</a>
+    <?php endif; ?>
+</p>
+
+<?php if (!count($batches)): ?>
+    <p>No review batches found.</p>
+<?php else: ?>
+    <table class="table table-striped table-bordered table-condensed">
+        <thead>
+            <tr>
+                <th>Created</th>
+                <th>Source tube</th>
+                <th>State</th>
+                <th>Review tube</th>
+                <th>Status</th>
+                <th>Progress</th>
+                <th></th>
+            </tr>
+        </thead>
+        <tbody>
+            <?php foreach ($batches as $batch): ?>
+                <tr<?php echo $sourceTube && isset($batch['source_tube']) && $batch['source_tube'] === $sourceTube ? ' class="info"' : ''; ?>>
+                    <td><?php echo htmlspecialchars($batch['created_at']); ?></td>
+                    <td><?php echo htmlspecialchars($batch['source_tube']); ?></td>
+                    <td><?php echo htmlspecialchars($batch['source_state']); ?></td>
+                    <td><?php echo htmlspecialchars($batch['review_tube']); ?></td>
+                    <td>
+                        <?php echo htmlspecialchars($batch['status']); ?>
+                        <?php if ($console->isReviewOwnedByAnotherSession($batch)): ?>
+                            <br><small class="text-warning">Be careful, this review batch was prepared by another session (visiting from <?php echo htmlspecialchars($console->getReviewOwnerIp($batch)); ?>).</small>
+                        <?php endif; ?>
+                    </td>
+                    <td><?php echo (int)$batch['processed']; ?> / <?php echo (int)$batch['target_count']; ?></td>
+                    <td>
+                        <a class="btn btn-xs btn-default" href="./?server=<?php echo urlencode($server); ?>&action=reviewBatchShow&batchId=<?php echo urlencode($batch['id']); ?>">Open</a>
+                        <a class="btn btn-xs btn-danger"
+                           href="./?server=<?php echo urlencode($server); ?>&action=reviewBatchDelete&batchId=<?php echo urlencode($batch['id']); ?>"
+                           onclick="return confirm('Delete this review batch and any remaining review-copy jobs?');">Delete</a>
+                    </td>
+                </tr>
+            <?php endforeach; ?>
+        </tbody>
+    </table>
+<?php endif; ?>

--- a/public/js/customer.js
+++ b/public/js/customer.js
@@ -192,6 +192,16 @@ $(document).ready(
                         document.location.replace($(this).data('href') + ($(this).val()));
                     }
                 });
+
+                // Review batch preparation guard: do not start a review for an empty state.
+                $('#reviewBatchStartSubmit').on('click', function () {
+                    var count = parseInt($('#reviewState option:selected').data('count'), 10) || 0;
+                    if (count === 0) {
+                        alert('The selected state has no jobs to review.');
+                        return false;
+                    }
+                    return true;
+                });
                 $(document).on('click', '#addServer', function () {
                     $('#servers-add').modal('toggle');
                     return false;
@@ -204,6 +214,85 @@ $(document).ready(
                         localStorage.setItem($(this).attr('id'), $(this).val());
                     }
                 });
+
+                // Review table controls: selection, bulk action guards, body expansion, and progress runners.
+                $('#reviewSelectAll').on('change', function () {
+                    $('.reviewJobCheckbox').prop('checked', $(this).is(':checked'));
+                });
+                $('#reviewSelectAllButton').on('click', function () {
+                    $('.reviewJobCheckbox').prop('checked', true);
+                    $('#reviewSelectAll').prop('checked', true);
+                    return false;
+                });
+                $('#reviewSelectNoneButton').on('click', function () {
+                    $('.reviewJobCheckbox').prop('checked', false);
+                    $('#reviewSelectAll').prop('checked', false);
+                    return false;
+                });
+                var lastReviewCheckbox = null;
+                $('.reviewJobCheckbox').on('click', function (e) {
+                    if (e.shiftKey && lastReviewCheckbox) {
+                        clearTextSelection();
+                        selectReviewCheckboxRange(lastReviewCheckbox, this, $(this).is(':checked'));
+                    }
+                    lastReviewCheckbox = this;
+                    updateReviewSelectAllState();
+                    e.stopPropagation();
+                });
+                $('.reviewJobCheckbox').closest('tr').on('click', function (e) {
+                    if ($(e.target).is('a, button, input, label, select, textarea') || $(e.target).closest('a, button, label').length) {
+                        return;
+                    }
+                    if (!e.shiftKey && window.getSelection && String(window.getSelection()).length > 0) {
+                        return;
+                    }
+                    var checkbox = $(this).find('.reviewJobCheckbox').get(0);
+                    if (!checkbox) {
+                        return;
+                    }
+                    if (e.shiftKey) {
+                        e.preventDefault();
+                        clearTextSelection();
+                    }
+                    checkbox.checked = !checkbox.checked;
+                    if (e.shiftKey && lastReviewCheckbox) {
+                        selectReviewCheckboxRange(lastReviewCheckbox, checkbox, checkbox.checked);
+                    }
+                    lastReviewCheckbox = checkbox;
+                    updateReviewSelectAllState();
+                });
+                $('.reviewJobView').on('click', function () {
+                    loadReviewJobBody($(this).data('review-id'), this);
+                    return false;
+                });
+                $('#reviewToggleBodies').on('click', function () {
+                    var $button = $(this);
+                    if ($button.data('expanded')) {
+                        showVisibleReviewPreviews();
+                        $button.data('expanded', 0).text('Show full bodies on this page');
+                    } else {
+                        showVisibleReviewBodies();
+                        $button.data('expanded', 1).text('Show previews');
+                    }
+                    return false;
+                });
+                $('button[data-confirm]').on('click', function () {
+                    if ($(this).data('requires-selection') && $('.reviewJobCheckbox:checked').length === 0) {
+                        alert('No review jobs are selected.');
+                        return false;
+                    }
+                    if ($(this).data('requires-moved') && (parseInt($('#reviewRemainingMovedCount').val(), 10) || 0) === 0) {
+                        alert('There are no remaining moved review jobs to process.');
+                        return false;
+                    }
+                    return confirm($(this).data('confirm'));
+                });
+                if ($('#reviewBatchProgress').length) {
+                    processReviewBatch();
+                }
+                if ($('#reviewBatchOperationProgress').length) {
+                    processReviewBatchOperation();
+                }
                 if (typeof (Storage) != "undefined") {
                     $('.kick_jobs_no').each(function () {
                         $(this).val(localStorage.getItem($(this).attr('id')) || 10);
@@ -224,6 +313,9 @@ $(document).ready(
 
                 if ($('#searchTubes').is(':visible')) { // Check if the element is visible
                     window.addEventListener("keydown",function (e) {
+                        if ($(e.target).is('input, textarea, select') || $(e.target).is('[contenteditable=true]')) {
+                            return;
+                        }
                         if (!e.ctrlKey && !e.altKey && !e.shiftKey && e.key.length === 1 && /^[a-zA-Z0-9]$/.test(e.key)) {
                             // Check if a single alphanumeric key was pressed
                             if (!$('#searchTubes').is(":focus") && !$('body').hasClass('modal-open')) {
@@ -325,6 +417,216 @@ $(document).ready(
                 $('#tubePriority').val('');
                 $('#tubeDelay').val('');
                 $('#tubeTtr').val('');
+            }
+
+            // Continue preparing a review batch one server-side chunk at a time.
+            function processReviewBatch() {
+                var $container = $('#reviewBatchProgress');
+                var batchId = $container.data('batch-id');
+                if (!batchId) {
+                    return;
+                }
+
+                $.ajax({
+                    'url': url + '&action=reviewBatchProcess',
+                    'data': {'batchId': batchId},
+                    'success': function (data) {
+                        if (!data || !data.batch) {
+                            $('#reviewBatchMessage').text('Unexpected response while processing the review batch.');
+                            return;
+                        }
+
+                        var batch = data.batch;
+                        var target = parseInt(batch.target_count, 10) || 0;
+                        var processed = parseInt(batch.processed, 10) || 0;
+                        var pct = target > 0 ? Math.min(100, Math.floor((processed / target) * 100)) : 100;
+
+                        $('#reviewBatchStatus').text(batch.status);
+                        $('#reviewBatchProcessed').text(processed);
+                        $('#reviewBatchTarget').text(target);
+                        $('#reviewBatchProgressBar').css('width', pct + '%');
+
+                        if (batch.status === 'processing') {
+                            setTimeout(processReviewBatch, 200);
+                        } else if (batch.status === 'complete' || batch.status === 'error') {
+                            window.location.href = $container.data('show-url');
+                        } else {
+                            $('#reviewBatchMessage').text(batch.error_message || batch.safety_message || 'Review batch stopped.');
+                        }
+                    },
+                    'type': 'POST',
+                    'dataType': 'json',
+                    'error': function () {
+                        $('#reviewBatchMessage').text('Error while processing the review batch.');
+                    }
+                });
+            }
+
+            // Continue a long-running all-return/all-delete review operation in chunks.
+            function processReviewBatchOperation() {
+                var $container = $('#reviewBatchOperationProgress');
+                var batchId = $container.data('batch-id');
+                if (!batchId) {
+                    return;
+                }
+
+                $.ajax({
+                    'url': url + '&action=reviewBatchOperationProcess',
+                    'data': {'batchId': batchId},
+                    'success': function (data) {
+                        if (!data || !data.operation) {
+                            $('#reviewBatchOperationMessage').text('Unexpected response while processing the review operation.');
+                            return;
+                        }
+
+                        var operation = data.operation;
+                        var target = parseInt(operation.target_count, 10) || 0;
+                        var processed = parseInt(operation.processed, 10) || 0;
+                        var pct = target > 0 ? Math.min(100, Math.floor((processed / target) * 100)) : 100;
+
+                        $('#reviewBatchOperationStatus').text(operation.status);
+                        $('#reviewBatchOperationProcessed').text(processed);
+                        $('#reviewBatchOperationTarget').text(target);
+                        $('#reviewBatchOperationErrors').text(operation.errors || 0);
+                        $('#reviewBatchOperationProgressBar').css('width', pct + '%');
+
+                        if (operation.status === 'processing') {
+                            setTimeout(processReviewBatchOperation, 200);
+                        } else if (operation.status === 'complete') {
+                            window.location.href = $container.data('show-url');
+                        } else {
+                            $('#reviewBatchOperationMessage').text(operation.error_message || 'Review operation stopped.');
+                        }
+                    },
+                    'type': 'POST',
+                    'dataType': 'json',
+                    'error': function () {
+                        $('#reviewBatchOperationMessage').text('Error while processing the review operation.');
+                    }
+                });
+            }
+
+            // Show one already-loaded review-copy body in the inspection modal.
+            function loadReviewJobBody(reviewId, button) {
+                var $button = button ? $(button) : $();
+                var $body = $('.reviewJobBodyFull[data-review-id="' + reviewId + '"]');
+
+                $('#reviewJobBodyContent').text('');
+                $('#reviewJobBodyModal').modal('show');
+
+                if (!$body.length) {
+                    $('#reviewJobBodyStats').html('<tr><td>Error</td><td>Job body is not available on this page.</td></tr>');
+                    return;
+                }
+
+                var rows = '';
+                rows += reviewJobStatRow('Original ID', $button.data('original-id'));
+                rows += reviewJobStatRow('Review ID', reviewId);
+                rows += reviewJobStatRow('Status', $button.data('status'));
+                rows += reviewJobStatRow('Priority', $button.data('pri'));
+                rows += reviewJobStatRow('TTR', $button.data('ttr'));
+                rows += reviewJobStatRow('Age', formatDuration($button.data('age')));
+                rows += reviewJobStatRow('Reserves', $button.data('reserves'));
+                rows += reviewJobStatRow('Buries', $button.data('buries'));
+                rows += reviewJobStatRow('Display', $body.data('content-type') || 'text');
+                $('#reviewJobBodyStats').html(rows);
+                $('#reviewJobBodyContent').text($body.text());
+            }
+
+            // Expand all visible preview cells using the full bodies already loaded with the page.
+            function showVisibleReviewBodies() {
+                $('.reviewJobBodyPreview').each(function () {
+                    var $preview = $(this);
+                    var reviewId = $preview.data('review-id');
+                    var $body = $('.reviewJobBodyFull[data-review-id="' + reviewId + '"]');
+
+                    if ($body.length) {
+                        $preview.text($body.text());
+                    } else {
+                        $preview.text('Job body is not available on this page.');
+                    }
+                });
+            }
+
+            function showVisibleReviewPreviews() {
+                $('.reviewJobBodyPreview').each(function () {
+                    $(this).text($(this).data('preview') || '');
+                });
+            }
+
+            // Render one metadata row in the review body modal.
+            function reviewJobStatRow(label, value) {
+                if (value === undefined || value === null || value === '') {
+                    value = '';
+                }
+                return '<tr><th>' + escapeHtml(label) + '</th><td>' + escapeHtml(String(value)) + '</td></tr>';
+            }
+
+            // Apply shift-click range selection across review job checkboxes.
+            function selectReviewCheckboxRange(first, second, checked) {
+                var boxes = $('.reviewJobCheckbox').toArray();
+                var firstIndex = boxes.indexOf(first);
+                var secondIndex = boxes.indexOf(second);
+                var start;
+                var end;
+
+                if (firstIndex < 0 || secondIndex < 0) {
+                    return;
+                }
+
+                start = Math.min(firstIndex, secondIndex);
+                end = Math.max(firstIndex, secondIndex);
+
+                for (var i = start; i <= end; i++) {
+                    boxes[i].checked = checked;
+                }
+            }
+
+            // Keep the header checkbox in sync with the visible row checkboxes.
+            function updateReviewSelectAllState() {
+                var $boxes = $('.reviewJobCheckbox');
+                var checkedCount = $boxes.filter(':checked').length;
+                $('#reviewSelectAll').prop('checked', $boxes.length > 0 && checkedCount === $boxes.length);
+            }
+
+            // Prevent accidental text highlighting while using shift-click range selection.
+            function clearTextSelection() {
+                if (window.getSelection) {
+                    window.getSelection().removeAllRanges();
+                } else if (document.selection) {
+                    document.selection.empty();
+                }
+            }
+
+            function formatDuration(value) {
+                value = parseInt(value, 10);
+                if (isNaN(value)) {
+                    return '';
+                }
+                var days = Math.floor(value / 86400);
+                var hours = Math.floor(value / 3600) % 24;
+                var minutes = Math.floor(value / 60) % 60;
+                var seconds = Math.floor(value % 60);
+                var parts = [];
+
+                if (days > 0) {
+                    parts.push('days: ' + days);
+                }
+                if (hours > 0) {
+                    parts.push('hours: ' + hours);
+                }
+                if (minutes > 0) {
+                    parts.push('minutes: ' + minutes);
+                }
+                if (seconds > 0 || parts.length === 0) {
+                    parts.push('seconds: ' + seconds);
+                }
+
+                return parts.join(', ');
+            }
+
+            function escapeHtml(value) {
+                return $('<div>').text(value).html();
             }
 
             function formatJson(val) {

--- a/public/js/customer.js
+++ b/public/js/customer.js
@@ -193,15 +193,55 @@ $(document).ready(
                     }
                 });
 
-                // Review batch preparation guard: do not start a review for an empty state.
-                $('#reviewBatchStartSubmit').on('click', function () {
-                    var count = parseInt($('#reviewState option:selected').data('count'), 10) || 0;
+                // Review batch preparation guard: keep state/count/safety controls aligned.
+                function updateReviewBatchStartState() {
+                    var $option = $('#reviewState option:selected');
+                    var count = parseInt($option.data('count'), 10) || 0;
+                    var forced = $('input[name="forceUnsafe"]').is(':checked') && parseInt($option.data('force-allowed'), 10) === 1;
+                    var allowed = parseInt($option.data('allowed'), 10) === 1 || forced;
+                    var message = $option.data('message') || '';
+                    var $limit = $('#reviewLimit');
+                    var limit = parseInt($limit.val(), 10) || 0;
+                    $limit.attr('max', count);
+                    if (limit < 1 || limit > count) {
+                        $limit.val(count);
+                    }
+                    $('#reviewSafetyMessage')
+                        .toggleClass('alert-info', allowed)
+                        .toggleClass('alert-warning', !allowed)
+                        .text(message);
+                    $('#reviewBatchStartSubmit').prop('disabled', count === 0 || !allowed);
+                    $('#reviewBatchPauseProceedSubmit').toggle(count > 0 && !allowed);
+                }
+                function validateReviewBatchStart(allowUnsafePause) {
+                    var $option = $('#reviewState option:selected');
+                    var count = parseInt($option.data('count'), 10) || 0;
+                    var forced = $('input[name="forceUnsafe"]').is(':checked') && parseInt($option.data('force-allowed'), 10) === 1;
+                    var allowed = parseInt($option.data('allowed'), 10) === 1 || forced;
+                    var limit = parseInt($('#reviewLimit').val(), 10) || 0;
                     if (count === 0) {
                         alert('The selected state has no jobs to review.');
                         return false;
                     }
+                    if (limit < 1 || limit > count) {
+                        alert('Jobs to review must be between 1 and the selected state count.');
+                        return false;
+                    }
+                    if (!allowed && !allowUnsafePause) {
+                        alert($option.data('message') || 'The selected state cannot be reviewed safely.');
+                        return false;
+                    }
                     return true;
+                }
+                $('#reviewState').on('change', updateReviewBatchStartState);
+                $('input[name="forceUnsafe"]').on('change', updateReviewBatchStartState);
+                $('#reviewBatchStartSubmit').on('click', function () {
+                    return validateReviewBatchStart(false);
                 });
+                $('#reviewBatchPauseProceedSubmit').on('click', function () {
+                    return validateReviewBatchStart(true);
+                });
+                updateReviewBatchStartState();
                 $(document).on('click', '#addServer', function () {
                     $('#servers-add').modal('toggle');
                     return false;
@@ -282,7 +322,11 @@ $(document).ready(
                         return false;
                     }
                     if ($(this).data('requires-moved') && (parseInt($('#reviewRemainingMovedCount').val(), 10) || 0) === 0) {
-                        alert('There are no remaining moved review jobs to process.');
+                        alert('There are no undecided review jobs to process.');
+                        return false;
+                    }
+                    if ($(this).data('requires-target') && $.trim($('#reviewTargetTube').val()) === '') {
+                        alert('Destination tube is required for this action.');
                         return false;
                     }
                     return confirm($(this).data('confirm'));

--- a/src/ReviewBatchNaming.php
+++ b/src/ReviewBatchNaming.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * Builds review batch names that should stay consistent across UI and backend fallbacks.
+ */
+class ReviewBatchNaming {
+
+    /**
+     * Returns the default review tube name for a source tube.
+     *
+     * The source tube stays first so sorted tube lists keep the review tube next to it.
+     *
+     * @param string $sourceTube Source tube name.
+     * @param string|null $suffix Unique suffix, or null to use the current timestamp.
+     * @return string
+     */
+    public static function defaultReviewTube($sourceTube, $suffix = null) {
+        if ($suffix === null) {
+            $suffix = date('Ymd-His');
+        }
+        return self::sanitizeTubePart($sourceTube) . '.REVIEW.' . self::sanitizeTubePart($suffix);
+    }
+
+    /**
+     * Sanitizes a tube-name part using the existing review batch naming character set.
+     *
+     * @param string $value Tube-name part.
+     * @return string
+     */
+    public static function sanitizeTubePart($value) {
+        return preg_replace('/[^A-Za-z0-9_.-]/', '_', $value);
+    }
+}

--- a/src/ReviewBatchPageBuilder.php
+++ b/src/ReviewBatchPageBuilder.php
@@ -157,7 +157,7 @@ class ReviewBatchPageBuilder {
      * @return bool
      */
     public function isReviewJobCleanupStatus($status) {
-        return in_array($status, array('copy_delete_error', 'return_delete_error'), true);
+        return in_array($status, array('copy_delete_error', 'return_delete_error', 'move_delete_error', 'duplicated'), true);
     }
 
     /**

--- a/src/ReviewBatchPageBuilder.php
+++ b/src/ReviewBatchPageBuilder.php
@@ -1,0 +1,266 @@
+<?php
+
+/**
+ * Builds review batch page data and owns review-specific display helpers.
+ */
+class ReviewBatchPageBuilder {
+
+    private $interface;
+    private $storage;
+
+    /**
+     * Stores queue and review storage dependencies.
+     *
+     * @param BeanstalkInterface $interface Queue interface wrapper.
+     * @param ReviewBatchStorage $storage Review batch storage.
+     */
+    public function __construct($interface, $storage) {
+        $this->interface = $interface;
+        $this->storage = $storage;
+    }
+
+    /**
+     * Builds template variables for the paginated review batch page.
+     *
+     * @param array $batch Review batch metadata.
+     * @param int $page One-based page number.
+     * @param int $perPage Page size.
+     * @param int $previewLength Maximum preview length.
+     * @return array Template variables for reviewBatchShow.
+     * @throws InvalidArgumentException If review storage cannot read or update the batch.
+     */
+    public function buildShowPage($batch, $page, $perPage, $previewLength) {
+        $activeOperation = $this->storage->loadOperation($batch['id']);
+        $offset = ($page - 1) * $perPage;
+        $summary = $this->storage->getBatchSummary($batch['id'], $offset, $perPage);
+        $jobs = $summary['jobs'];
+        $previews = array();
+        $bodies = array();
+        $previewReviewIds = array();
+        $reviewJobIndexes = array();
+        $manifestUpdated = false;
+
+        // First identify visible rows that should still have a review-copy body to inspect.
+        foreach ($jobs as $jobIndex => $job) {
+            if ($this->reviewJobHasInspectableCopy($job)) {
+                $reviewId = (int)$job['review_id'];
+                $previewReviewIds[] = $reviewId;
+                $reviewJobIndexes[$reviewId] = $jobIndex;
+            }
+        }
+
+        // Body snapshots are preferred because they show the exact payload captured during preparation.
+        $bodySnapshots = !empty($batch['include_body_snapshot'])
+                ? $this->storage->getBodySnapshots($batch['id'], $previewReviewIds)
+                : array();
+        foreach ($previewReviewIds as $reviewId) {
+            if (isset($bodySnapshots[$reviewId])) {
+                $display = $this->formatJobBodyForDisplay($bodySnapshots[$reviewId]['body'], false);
+                $bodies[$reviewId] = array(
+                    'body' => $display['body'],
+                    'content_type' => $display['content_type'],
+                    'body_source' => 'snapshot',
+                );
+                $previews[$reviewId] = $this->truncateReviewBody($display['body'], $previewLength);
+                continue;
+            }
+
+            try {
+                $display = $this->getLiveReviewJobBodyDisplay($reviewId);
+                $bodies[$reviewId] = array(
+                    'body' => $display['body'],
+                    'content_type' => $display['content_type'],
+                    'body_source' => 'live',
+                );
+                $previews[$reviewId] = $this->truncateReviewBody($display['body'], $previewLength);
+            } catch (Exception $e) {
+                if ($this->isBeanstalkNotFound($e)) {
+                    // Missing review copies are reflected back into the manifest before rendering.
+                    $jobIndex = isset($reviewJobIndexes[$reviewId]) ? $reviewJobIndexes[$reviewId] : null;
+                    $this->storage->updateJob($batch['id'], array(
+                        'original_id' => $jobIndex !== null && isset($jobs[$jobIndex]['original_id']) ? $jobs[$jobIndex]['original_id'] : null,
+                        'review_id' => $reviewId,
+                        'status' => 'missing_review_job',
+                        'error_message' => $e->getMessage(),
+                    ));
+                    if ($jobIndex !== null) {
+                        $jobs[$jobIndex]['status'] = 'missing_review_job';
+                        $jobs[$jobIndex]['error_message'] = $e->getMessage();
+                    }
+                    $manifestUpdated = true;
+                    $previews[$reviewId] = '';
+                    continue;
+                }
+
+                $message = 'Unable to load review body: ' . $e->getMessage();
+                $bodies[$reviewId] = array(
+                    'body' => $message,
+                    'content_type' => 'text',
+                    'body_source' => 'error',
+                );
+                $previews[$reviewId] = $this->truncateReviewBody($message, $previewLength);
+            }
+        }
+
+        if ($manifestUpdated) {
+            $summary = $this->storage->getBatchSummary($batch['id'], $offset, $perPage);
+            $jobs = $summary['jobs'];
+        }
+
+        return array(
+            'reviewBatch' => $batch,
+            'reviewOperation' => $activeOperation,
+            'reviewJobs' => $jobs,
+            'reviewJobsTotal' => $summary['total'],
+            'reviewPage' => $page,
+            'reviewPerPage' => $perPage,
+            'reviewRemainingMovedCount' => $summary['moved_count'],
+            'reviewPageSelectableCount' => $summary['page_selectable_count'],
+            'reviewPageBodyCount' => count($bodies),
+            'reviewJobPreviews' => $previews,
+            'reviewJobBodies' => $bodies,
+        );
+    }
+
+    /**
+     * Returns a formatted display body for a live review-copy job.
+     *
+     * @param int $reviewId Review-copy job id.
+     * @return array
+     * @throws Exception If the live review-copy job cannot be peeked.
+     */
+    public function getLiveReviewJobBodyDisplay($reviewId) {
+        $job = $this->interface->_client->peek((int)$reviewId);
+        if (!$job) {
+            throw new Exception('Review job not found');
+        }
+        return $this->formatJobBodyForDisplay($job->getData(), false);
+    }
+
+    /**
+     * Returns whether the collapsed manifest row should still have a review-copy job to inspect.
+     *
+     * @param array $job Collapsed manifest row.
+     * @return bool
+     */
+    public function reviewJobHasInspectableCopy($job) {
+        if (!isset($job['status'], $job['review_id']) || (int)$job['review_id'] <= 0) {
+            return false;
+        }
+        return $job['status'] === 'moved' || $this->isReviewJobCleanupStatus($job['status']);
+    }
+
+    /**
+     * Returns whether the manifest status represents a leftover review copy needing cleanup.
+     *
+     * @param string $status Manifest status.
+     * @return bool
+     */
+    public function isReviewJobCleanupStatus($status) {
+        return in_array($status, array('copy_delete_error', 'return_delete_error'), true);
+    }
+
+    /**
+     * Truncates a formatted body for table preview display.
+     *
+     * @param string $body Formatted job body.
+     * @param int $length Maximum preview length.
+     * @return string
+     */
+    public function truncateReviewBody($body, $length = 100) {
+        if (strlen($body) > $length) {
+            return substr($body, 0, $length) . '...';
+        }
+        return $body;
+    }
+
+    /**
+     * Formats a seconds value in the same days/hours/minutes/seconds style as job stats.
+     *
+     * @param int $value Duration in seconds.
+     * @return string
+     */
+    public function formatDuration($value) {
+        $value = (int)$value;
+        $days = floor($value / 86400);
+        $hours = floor($value / 3600) % 24;
+        $minutes = floor($value / 60) % 60;
+        $seconds = floor($value % 60);
+        $parts = array();
+
+        if ($days > 0) {
+            $parts[] = 'days: ' . $days;
+        }
+        if ($hours > 0) {
+            $parts[] = 'hours: ' . $hours;
+        }
+        if ($minutes > 0) {
+            $parts[] = 'minutes: ' . $minutes;
+        }
+        if ($seconds > 0 || !count($parts)) {
+            $parts[] = 'seconds: ' . $seconds;
+        }
+
+        return implode('<br>', $parts);
+    }
+
+    /**
+     * Applies configured body decoders and formats a job body for display/export.
+     *
+     * @param string $body Raw job body.
+     * @param bool $html Whether to HTML-escape the formatted body.
+     * @return array
+     */
+    public function formatJobBodyForDisplay($body, $html) {
+        $settings = new Settings();
+        $contentType = 'text';
+        $display = $body;
+
+        if ($settings->isBase64DecodeEnabled()) {
+            $decoded = base64_decode($display, true);
+            if ($decoded !== false) {
+                $display = $decoded;
+                $contentType = 'base64';
+            }
+        }
+
+        if ($settings->isUnserializationEnabled()) {
+            $unserialized = @unserialize($display);
+            if ($unserialized !== false || $display === serialize(false)) {
+                $display = print_r($unserialized, true);
+                $contentType = 'php';
+            }
+        }
+
+        if ($settings->isJsonDecodeEnabled()) {
+            $decodedJson = json_decode($display, true);
+            if (json_last_error() === JSON_ERROR_NONE) {
+                $display = json_encode($decodedJson, JSON_PRETTY_PRINT);
+                $contentType = 'json';
+            }
+        }
+
+        if (!is_string($display)) {
+            $display = print_r($display, true);
+        }
+        if (!preg_match('//u', $display)) {
+            $display = base64_encode($display);
+            $contentType = 'base64';
+        }
+
+        return array(
+            'body' => $html ? htmlspecialchars($display) : $display,
+            'content_type' => $contentType,
+        );
+    }
+
+    /**
+     * Detects beanstalkd NOT_FOUND errors so missing review copies can be reconciled.
+     *
+     * @param Exception $e Queue exception.
+     * @return bool
+     */
+    public function isBeanstalkNotFound($e) {
+        return strpos($e->getMessage(), Pheanstalk_Response::RESPONSE_NOT_FOUND) !== false;
+    }
+}

--- a/src/ReviewBatchService.php
+++ b/src/ReviewBatchService.php
@@ -92,8 +92,8 @@ class ReviewBatchService {
     }
 
     /**
-     * Applies one return/delete operation to one review-copy job and records the outcome.
-     * If returning succeeds but review-copy deletion fails, records return_delete_error for cleanup.
+     * Applies one review operation to one review-copy job and records the outcome.
+     * If an operation creates another queue copy but review-copy deletion fails, records a cleanup status.
      *
      * @param array $batch Review batch metadata.
      * @param array $manifestJob Collapsed manifest row for the review-copy job.
@@ -104,31 +104,60 @@ class ReviewBatchService {
     public function operateReviewJob($batch, $manifestJob, $operation) {
         $operationType = isset($operation['operation']) ? $operation['operation'] : '';
         $delay = isset($operation['delay']) ? (int)$operation['delay'] : 0;
+        $targetTube = isset($operation['target_tube']) ? $operation['target_tube'] : '';
+        $priority = isset($manifestJob['pri']) ? (int)$manifestJob['pri'] : Pheanstalk::DEFAULT_PRIORITY;
+        $ttr = isset($manifestJob['ttr']) ? (int)$manifestJob['ttr'] : Pheanstalk::DEFAULT_TTR;
         $baseRow = $this->buildOperationRow($manifestJob);
 
         try {
             $reviewJob = $this->interface->_client->peek((int)$manifestJob['review_id']);
-            if ($operationType === 'return_all_moved') {
-                $priority = isset($manifestJob['pri']) ? (int)$manifestJob['pri'] : Pheanstalk::DEFAULT_PRIORITY;
-                $ttr = isset($manifestJob['ttr']) ? (int)$manifestJob['ttr'] : Pheanstalk::DEFAULT_TTR;
-                // Recreate the job in the source tube before removing the isolated review copy.
-                $returnedId = $this->interface->addJob($batch['source_tube'], $reviewJob->getData(), $priority, $delay, $ttr);
+            if ($operationType === 'move_all_moved') {
+                // Write the destination copy first. If destination is the source tube, this is a return.
+                $targetId = $this->interface->addJob($targetTube, $reviewJob->getData(), $priority, $delay, $ttr);
                 try {
                     $this->interface->_client->delete($reviewJob);
                 } catch (Exception $e) {
-                    // The source job now exists, so keep the remaining review copy visible for cleanup.
-                    $this->storage->updateJob($batch['id'], array_merge($baseRow, array(
-                        'returned_id' => $returnedId,
-                        'return_delay' => $delay,
-                        'status' => 'return_delete_error',
+                    // The destination job now exists, so keep the remaining review copy visible for cleanup.
+                    $errorRow = array(
+                        'status' => $targetTube === $batch['source_tube'] ? 'return_delete_error' : 'move_delete_error',
                         'error_message' => $e->getMessage(),
-                    )));
+                    );
+                    if ($targetTube === $batch['source_tube']) {
+                        $errorRow['returned_id'] = $targetId;
+                        $errorRow['return_delay'] = $delay;
+                    } else {
+                        $errorRow['target_tube'] = $targetTube;
+                        $errorRow['target_id'] = $targetId;
+                        $errorRow['target_delay'] = $delay;
+                    }
+                    $this->storage->updateJob($batch['id'], array_merge($baseRow, $errorRow));
                     return false;
                 }
+                if ($targetTube === $batch['source_tube']) {
+                    $this->storage->updateJob($batch['id'], array_merge($baseRow, array(
+                        'returned_id' => $targetId,
+                        'return_delay' => $delay,
+                        'status' => 'returned',
+                    )));
+                } else {
+                    $this->storage->updateJob($batch['id'], array_merge($baseRow, array(
+                        'target_tube' => $targetTube,
+                        'target_id' => $targetId,
+                        'target_delay' => $delay,
+                        'status' => 'moved_to_tube',
+                    )));
+                }
+                return true;
+            }
+
+            if ($operationType === 'duplicate_all_moved') {
+                // Duplicate intentionally leaves the review copy in place for continued inspection/cleanup.
+                $targetId = $this->interface->addJob($targetTube, $reviewJob->getData(), $priority, $delay, $ttr);
                 $this->storage->updateJob($batch['id'], array_merge($baseRow, array(
-                    'returned_id' => $returnedId,
-                    'return_delay' => $delay,
-                    'status' => 'returned',
+                    'target_tube' => $targetTube,
+                    'target_id' => $targetId,
+                    'target_delay' => $delay,
+                    'status' => 'duplicated',
                 )));
                 return true;
             }

--- a/src/ReviewBatchService.php
+++ b/src/ReviewBatchService.php
@@ -1,0 +1,275 @@
+<?php
+
+/**
+ * Coordinates review batch queue operations and manifest writes.
+ */
+class ReviewBatchService {
+
+    private $interface;
+    private $storage;
+
+    /**
+     * Stores the queue interface and review storage dependencies.
+     *
+     * @param BeanstalkInterface $interface Queue interface wrapper.
+     * @param ReviewBatchStorage $storage Review batch storage.
+     */
+    public function __construct($interface, $storage) {
+        $this->interface = $interface;
+        $this->storage = $storage;
+    }
+
+    /**
+     * Copies jobs into the review tube, removes them from the source state, and records manifest rows.
+     * If copying succeeds but source deletion fails, the review copy is recorded as copy_delete_error.
+     *
+     * @param array $batch Review batch metadata.
+     * @param int $chunkSize Maximum jobs to process in this chunk.
+     * @return array Updated review batch metadata.
+     * @throws InvalidArgumentException If storage cannot record the chunk result.
+     */
+    public function processPreparationChunk($batch, $chunkSize) {
+        $bodySnapshotRows = array();
+
+        for ($i = 0; $i < $chunkSize; $i++) {
+            if ((int)$batch['processed'] >= (int)$batch['target_count']) {
+                $batch['status'] = 'complete';
+                break;
+            }
+
+            $job = null;
+            $stats = array();
+            $reviewId = null;
+            $sourceDeleted = false;
+            try {
+                // Claim the next source job only long enough to copy it into the isolated review tube.
+                $job = $this->peekJobByState($batch['source_tube'], $batch['source_state']);
+                if (!$job) {
+                    $batch['status'] = 'complete';
+                    break;
+                }
+
+                $stats = $this->interface->_client->statsJob($job);
+                $priority = isset($stats['pri']) ? (int)$stats['pri'] : Pheanstalk::DEFAULT_PRIORITY;
+                $ttr = isset($stats['ttr']) ? (int)$stats['ttr'] : Pheanstalk::DEFAULT_TTR;
+                $reviewId = $this->interface->addJob($batch['review_tube'], $job->getData(), $priority, 0, $ttr);
+
+                // Only after the review copy exists do we remove the original from the source state.
+                $this->interface->_client->delete($job);
+                $sourceDeleted = true;
+                $row = $this->buildReviewJobRow($job, $stats, $reviewId, 'moved');
+                $this->storage->appendJob($batch['id'], $row);
+                if (!empty($batch['include_body_snapshot'])) {
+                    $bodySnapshotRows[] = $this->buildBodySnapshotRow($row, $job);
+                }
+                $batch['processed'] = (int)$batch['processed'] + 1;
+            } catch (Exception $e) {
+                $batch['errors'] = (int)$batch['errors'] + 1;
+                $batch['status'] = 'error';
+                $batch['error_message'] = $e->getMessage();
+                // If the copy exists but source cleanup failed, keep it visible for inspection/deletion.
+                $status = ($reviewId !== null && !$sourceDeleted) ? 'copy_delete_error' : 'error';
+                $row = $this->buildReviewJobErrorRow($job, $stats, $reviewId, $e->getMessage(), $status);
+                $this->storage->appendJob($batch['id'], $row);
+                if (!empty($batch['include_body_snapshot']) && $job && $reviewId !== null) {
+                    $bodySnapshotRows[] = $this->buildBodySnapshotRow($row, $job);
+                }
+                break;
+            }
+        }
+
+        if (!empty($batch['include_body_snapshot'])) {
+            // Snapshot writes are batched so the body file/index are touched once per chunk.
+            $this->storage->appendBodySnapshotRows($batch['id'], $bodySnapshotRows);
+        }
+
+        if ((int)$batch['processed'] >= (int)$batch['target_count'] && $batch['status'] === 'processing') {
+            $batch['status'] = 'complete';
+        }
+
+        $this->storage->saveBatch($batch);
+        return $batch;
+    }
+
+    /**
+     * Applies one return/delete operation to one review-copy job and records the outcome.
+     * If returning succeeds but review-copy deletion fails, records return_delete_error for cleanup.
+     *
+     * @param array $batch Review batch metadata.
+     * @param array $manifestJob Collapsed manifest row for the review-copy job.
+     * @param array $operation Operation metadata.
+     * @return bool True when the queue operation succeeds, false when it is recorded as missing or failed.
+     * @throws InvalidArgumentException If storage cannot record the operation outcome.
+     */
+    public function operateReviewJob($batch, $manifestJob, $operation) {
+        $operationType = isset($operation['operation']) ? $operation['operation'] : '';
+        $delay = isset($operation['delay']) ? (int)$operation['delay'] : 0;
+        $baseRow = $this->buildOperationRow($manifestJob);
+
+        try {
+            $reviewJob = $this->interface->_client->peek((int)$manifestJob['review_id']);
+            if ($operationType === 'return_all_moved') {
+                $priority = isset($manifestJob['pri']) ? (int)$manifestJob['pri'] : Pheanstalk::DEFAULT_PRIORITY;
+                $ttr = isset($manifestJob['ttr']) ? (int)$manifestJob['ttr'] : Pheanstalk::DEFAULT_TTR;
+                // Recreate the job in the source tube before removing the isolated review copy.
+                $returnedId = $this->interface->addJob($batch['source_tube'], $reviewJob->getData(), $priority, $delay, $ttr);
+                try {
+                    $this->interface->_client->delete($reviewJob);
+                } catch (Exception $e) {
+                    // The source job now exists, so keep the remaining review copy visible for cleanup.
+                    $this->storage->updateJob($batch['id'], array_merge($baseRow, array(
+                        'returned_id' => $returnedId,
+                        'return_delay' => $delay,
+                        'status' => 'return_delete_error',
+                        'error_message' => $e->getMessage(),
+                    )));
+                    return false;
+                }
+                $this->storage->updateJob($batch['id'], array_merge($baseRow, array(
+                    'returned_id' => $returnedId,
+                    'return_delay' => $delay,
+                    'status' => 'returned',
+                )));
+                return true;
+            }
+
+            if ($operationType === 'delete_all_moved') {
+                // Delete is one-way for the review copy; no source job is recreated.
+                $this->interface->_client->delete($reviewJob);
+                $this->storage->updateJob($batch['id'], array_merge($baseRow, array(
+                    'status' => 'deleted',
+                )));
+                return true;
+            }
+        } catch (Exception $e) {
+            if ($this->isBeanstalkNotFound($e)) {
+                // A missing review copy is already gone for deletes, but blocks returns.
+                $this->storage->updateJob($batch['id'], array_merge($baseRow, array(
+                    'status' => $operationType === 'delete_all_moved' ? 'deleted' : 'missing_review_job',
+                    'error_message' => $e->getMessage(),
+                )));
+            } else {
+                $this->storage->updateJob($batch['id'], array_merge($baseRow, array(
+                    'status' => 'operation_error',
+                    'error_message' => $e->getMessage(),
+                )));
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Peeks the next job in the selected state for the source tube.
+     *
+     * @param string $tube Source tube name.
+     * @param string $state Source state: ready, delayed, or buried.
+     * @return Pheanstalk_Job|false
+     * @throws Exception If beanstalkd returns an unexpected error.
+     */
+    private function peekJobByState($tube, $state) {
+        try {
+            switch ($state) {
+                case 'ready':
+                    return $this->interface->_client->useTube($tube)->peekReady();
+                case 'delayed':
+                    return $this->interface->_client->useTube($tube)->peekDelayed();
+                case 'buried':
+                    return $this->interface->_client->useTube($tube)->peekBuried();
+            }
+        } catch (Exception $e) {
+            if ($this->isBeanstalkNotFound($e)) {
+                return false;
+            }
+            throw $e;
+        }
+        return false;
+    }
+
+    /**
+     * Builds the audit row describing one review job and its original stats.
+     *
+     * @param Pheanstalk_Job $job Original beanstalkd job.
+     * @param array $stats Original job stats.
+     * @param int $reviewId Review-copy job id.
+     * @param string $status Manifest status.
+     * @return array
+     */
+    private function buildReviewJobRow($job, $stats, $reviewId, $status) {
+        $fields = array('pri', 'age', 'delay', 'ttr', 'time-left', 'file', 'reserves', 'timeouts', 'releases', 'buries', 'kicks');
+        $row = array(
+            'original_id' => $job->getId(),
+            'review_id' => $reviewId,
+            'status' => $status,
+        );
+        foreach ($fields as $field) {
+            if (isset($stats[$field])) {
+                $row[$field] = is_numeric($stats[$field]) ? (int)$stats[$field] : $stats[$field];
+            }
+        }
+        if (isset($stats['age'])) {
+            $row['job_created_at'] = date('c', time() - (int)$stats['age']);
+        }
+        return $row;
+    }
+
+    /**
+     * Builds a compact audit row for the job that stopped review preparation.
+     *
+     * @param Pheanstalk_Job|null $job Original beanstalkd job, when one was available.
+     * @param array $stats Original job stats, when available.
+     * @param int|null $reviewId Review-copy job id, when one was created.
+     * @param string $message Error message.
+     * @param string $status Manifest status.
+     * @return array
+     */
+    private function buildReviewJobErrorRow($job, $stats, $reviewId, $message, $status = 'error') {
+        if ($job) {
+            $row = $this->buildReviewJobRow($job, $stats, $reviewId, $status);
+        } else {
+            $row = array('status' => $status);
+            if ($reviewId !== null) {
+                $row['review_id'] = $reviewId;
+            }
+        }
+        $row['error_message'] = $message;
+        return $row;
+    }
+
+    /**
+     * Builds the body snapshot row stored beside the audit manifest.
+     *
+     * @param array $row Manifest row for the reviewed job.
+     * @param Pheanstalk_Job $job Original beanstalkd job.
+     * @return array
+     */
+    private function buildBodySnapshotRow($row, $job) {
+        $row['status'] = 'snapshot';
+        $row['body_encoding'] = 'base64';
+        $row['body_base64'] = base64_encode($job->getData());
+        return $row;
+    }
+
+    /**
+     * Builds manifest fields shared by review return/delete operation outcomes.
+     *
+     * @param array $manifestJob Collapsed manifest row for the review-copy job.
+     * @return array
+     */
+    private function buildOperationRow($manifestJob) {
+        return array(
+            'original_id' => isset($manifestJob['original_id']) ? $manifestJob['original_id'] : null,
+            'review_id' => isset($manifestJob['review_id']) ? $manifestJob['review_id'] : null,
+        );
+    }
+
+    /**
+     * Detects beanstalkd NOT_FOUND errors.
+     *
+     * @param Exception $e Queue exception.
+     * @return bool
+     */
+    private function isBeanstalkNotFound($e) {
+        return strpos($e->getMessage(), Pheanstalk_Response::RESPONSE_NOT_FOUND) !== false;
+    }
+}

--- a/src/ReviewBatchStorage.php
+++ b/src/ReviewBatchStorage.php
@@ -300,7 +300,7 @@ class ReviewBatchStorage {
 
         $pageSelectableCount = 0;
         foreach ($pageJobs as $job) {
-            if (isset($job['status'], $job['review_id']) && $job['status'] === 'moved' && (int)$job['review_id'] > 0) {
+            if (isset($job['status'], $job['review_id']) && in_array($job['status'], array('moved', 'duplicated'), true) && (int)$job['review_id'] > 0) {
                 $pageSelectableCount++;
             }
         }

--- a/src/ReviewBatchStorage.php
+++ b/src/ReviewBatchStorage.php
@@ -1,0 +1,1074 @@
+<?php
+
+/**
+ * Stores review batch metadata, append-only audit manifests, materialized current state, body snapshots,
+ * and long-running operation state.
+ */
+class ReviewBatchStorage {
+
+    private $path;
+    private $error;
+
+    /**
+     * Resolves the review storage directory from config and verifies it is usable.
+     *
+     * @param array $config Application configuration.
+     * @throws InvalidArgumentException If the storage directory cannot be created or written.
+     */
+    public function __construct($config) {
+        if (!empty($config['review']['storagePath'])) {
+            $this->path = $config['review']['storagePath'];
+        } else {
+            $this->path = dirname($config['storage']) . DIRECTORY_SEPARATOR . 'review-batches';
+        }
+
+        if (!$this->isAvailable()) {
+            throw new InvalidArgumentException($this->error);
+        }
+    }
+
+    /**
+     * Ensures the review storage directory exists and is writable.
+     *
+     * @return bool
+     */
+    public function isAvailable() {
+        if (!is_dir($this->path) && !mkdir($this->path, 0755, true)) {
+            $this->error = 'Review batch storage directory could not be created: ' . $this->path;
+            return false;
+        }
+        if (!is_writable($this->path)) {
+            $this->error = 'Review batch storage directory must be writable: ' . $this->path;
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Returns the last storage availability error message.
+     *
+     * @return string|null
+     */
+    public function getError() {
+        return $this->error;
+    }
+
+    /**
+     * Creates metadata and empty manifest files for a new review batch.
+     *
+     * @param array $batch Review batch metadata.
+     * @return array
+     * @throws InvalidArgumentException If batch storage files cannot be written.
+     */
+    public function createBatch($batch) {
+        $this->saveBatch($batch);
+        $this->writeFile($this->jobsFile($batch['id']), '');
+        $this->writeCurrentState($batch['id'], $this->emptyCurrentState(0));
+        if (!empty($batch['include_body_snapshot'])) {
+            $this->writeFile($this->bodySnapshotFile($batch['id']), '');
+            $this->writeFile($this->bodySnapshotIndexFile($batch['id']), '');
+        }
+        return $batch;
+    }
+
+    /**
+     * Persists review batch metadata.
+     *
+     * @param array $batch Review batch metadata.
+     * @return void
+     * @throws InvalidArgumentException If metadata cannot be encoded or written.
+     */
+    public function saveBatch($batch) {
+        $this->writeJsonFile($this->batchFile($batch['id']), $batch);
+    }
+
+    /**
+     * Updates ownership fields on an existing review batch.
+     *
+     * @param string $batchId Batch id.
+     * @param string $sessionId New owner session id.
+     * @param string $ip New owner IP.
+     * @return array Updated batch metadata.
+     * @throws InvalidArgumentException If the batch is missing or metadata cannot be saved.
+     */
+    public function takeOverBatch($batchId, $sessionId, $ip) {
+        $batch = $this->loadBatch($batchId);
+        if (!$batch) {
+            throw new InvalidArgumentException('Review batch not found');
+        }
+        $batch['previous_owner_session_id'] = isset($batch['owner_session_id']) ? $batch['owner_session_id'] : '';
+        $batch['previous_owner_ip'] = isset($batch['owner_ip']) ? $batch['owner_ip'] : '';
+        $batch['owner_session_id'] = $sessionId;
+        $batch['owner_ip'] = $ip;
+        $batch['owner_taken_over_at'] = date('c');
+        $this->saveBatch($batch);
+        return $batch;
+    }
+
+    /**
+     * Loads review batch metadata by batch id.
+     *
+     * @param string $id Batch id.
+     * @return array|false
+     */
+    public function loadBatch($id) {
+        $file = $this->batchFile($id);
+        if (!is_file($file)) {
+            $file = $this->legacyBatchFile($id);
+        }
+        if (!is_file($file)) {
+            return false;
+        }
+        return $this->readJsonFile($file);
+    }
+
+    /**
+     * Lists all stored review batches, newest first.
+     *
+     * @return array
+     */
+    public function listBatches() {
+        $result = array();
+        $files = glob($this->path . DIRECTORY_SEPARATOR . '*.batch.json');
+        if (!is_array($files)) {
+            $files = array();
+        }
+        $legacyFiles = glob($this->path . DIRECTORY_SEPARATOR . '*.json');
+        if (!is_array($legacyFiles)) {
+            $legacyFiles = array();
+        }
+        foreach ($legacyFiles as $file) {
+            if (substr($file, -11) === '.batch.json' || substr($file, -13) === '.current.json' || substr($file, -15) === '.operation.json') {
+                continue;
+            }
+            $files[] = $file;
+        }
+        foreach ($files as $file) {
+            $batch = $this->readJsonFile($file);
+            if (is_array($batch) && isset($batch['id'])) {
+                $result[$batch['id']] = $batch;
+            }
+        }
+        $result = array_values($result);
+        usort($result, array($this, 'sortBatchesNewestFirst'));
+        return $result;
+    }
+
+    /**
+     * Appends one audit event row to the review manifest and syncs the materialized current state.
+     *
+     * @param string $batchId Batch id.
+     * @param array $row Manifest row.
+     * @return void
+     * @throws InvalidArgumentException If the row cannot be encoded, appended, or reflected in current state.
+     */
+    public function appendJob($batchId, $row) {
+        if (!isset($row['event_at'])) {
+            $row['event_at'] = date('c');
+        }
+        $current = $this->loadCurrentStateForAppend($batchId);
+        $line = $this->encodeJson($row) . "\n";
+        $this->appendFile($this->jobsFile($batchId), $line);
+        $this->applyCurrentStateRow($current, $row);
+        $current['audit_size'] = $this->getAuditSize($batchId);
+        $current['updated_at'] = date('c');
+        $this->writeCurrentState($batchId, $current);
+    }
+
+    /**
+     * Appends a chunk of body snapshot rows captured during review preparation.
+     *
+     * @param string $batchId Batch id.
+     * @param array $rows Body snapshot rows.
+     * @return void
+     * @throws InvalidArgumentException If the snapshot or index cannot be encoded, locked, or written.
+     */
+    public function appendBodySnapshotRows($batchId, $rows) {
+        if (!count($rows)) {
+            return;
+        }
+
+        $snapshotFile = $this->bodySnapshotFile($batchId);
+        $indexData = '';
+        $snapshotHandle = fopen($snapshotFile, 'ab');
+        if (!$snapshotHandle) {
+            throw new InvalidArgumentException('Review batch body snapshot could not be opened: ' . $snapshotFile);
+        }
+        if (!flock($snapshotHandle, LOCK_EX)) {
+            fclose($snapshotHandle);
+            throw new InvalidArgumentException('Review batch body snapshot could not be locked: ' . $snapshotFile);
+        }
+
+        try {
+            if (fseek($snapshotHandle, 0, SEEK_END) !== 0) {
+                throw new InvalidArgumentException('Review batch body snapshot could not be sought: ' . $snapshotFile);
+            }
+            $offset = ftell($snapshotHandle);
+            if ($offset === false) {
+                throw new InvalidArgumentException('Review batch body snapshot offset could not be read: ' . $snapshotFile);
+            }
+
+            foreach ($rows as $row) {
+                if (!isset($row['snapshot_at'])) {
+                    $row['snapshot_at'] = date('c');
+                }
+                $line = $this->encodeJson($row) . "\n";
+                $length = strlen($line);
+                $this->writeAll($snapshotHandle, $line, $snapshotFile);
+                if (isset($row['review_id'])) {
+                    $indexData .= $this->encodeJson(array(
+                        'review_id' => (int)$row['review_id'],
+                        'offset' => $offset,
+                        'length' => $length,
+                    )) . "\n";
+                }
+                $offset += $length;
+            }
+
+            if (!fflush($snapshotHandle)) {
+                throw new InvalidArgumentException('Review batch body snapshot could not be flushed: ' . $snapshotFile);
+            }
+        } catch (Exception $e) {
+            flock($snapshotHandle, LOCK_UN);
+            fclose($snapshotHandle);
+            throw $e;
+        }
+
+        flock($snapshotHandle, LOCK_UN);
+        fclose($snapshotHandle);
+
+        if ($indexData !== '') {
+            $this->appendFile($this->bodySnapshotIndexFile($batchId), $indexData);
+        }
+    }
+
+    /**
+     * Records a new audit event for an existing reviewed job.
+     *
+     * @param string $batchId Batch id.
+     * @param array $row Manifest row.
+     * @return void
+     * @throws InvalidArgumentException If the row cannot be encoded or appended.
+     */
+    public function updateJob($batchId, $row) {
+        $this->appendJob($batchId, $row);
+    }
+
+    /**
+     * Returns a paginated collapsed view of the review manifest.
+     *
+     * @param string $batchId Batch id.
+     * @param int $offset Zero-based row offset.
+     * @param int $limit Maximum number of rows.
+     * @return array
+     */
+    public function getJobs($batchId, $offset, $limit) {
+        $summary = $this->getBatchSummary($batchId, $offset, $limit);
+        return $summary['jobs'];
+    }
+
+    /**
+     * Counts reviewed jobs after collapsing manifest events by job.
+     *
+     * @param string $batchId Batch id.
+     * @return int
+     */
+    public function countJobs($batchId) {
+        $summary = $this->getBatchSummary($batchId, 0, 0);
+        return $summary['total'];
+    }
+
+    /**
+     * Returns collapsed jobs plus aggregate counts from materialized current state.
+     *
+     * @param string $batchId Batch id.
+     * @param int $offset Zero-based row offset.
+     * @param int|null $limit Maximum rows, or null for all remaining rows.
+     * @return array
+     */
+    public function getBatchSummary($batchId, $offset = 0, $limit = null) {
+        $current = $this->loadCurrentState($batchId);
+        $jobs = array_values($current['jobs']);
+        $total = (int)$current['total'];
+        $movedCount = (int)$current['moved_count'];
+
+        if ($limit === null) {
+            $pageJobs = array_slice($jobs, $offset);
+        } else {
+            $pageJobs = array_slice($jobs, $offset, $limit);
+        }
+
+        $pageSelectableCount = 0;
+        foreach ($pageJobs as $job) {
+            if (isset($job['status'], $job['review_id']) && $job['status'] === 'moved' && (int)$job['review_id'] > 0) {
+                $pageSelectableCount++;
+            }
+        }
+
+        return array(
+            'jobs' => $pageJobs,
+            'total' => $total,
+            'moved_count' => $movedCount,
+            'page_selectable_count' => $pageSelectableCount,
+        );
+    }
+
+    /**
+     * Returns the next moved review jobs for chunked operations from materialized current state.
+     *
+     * @param string $batchId Batch id.
+     * @param int $limit Maximum number of moved jobs to return.
+     * @return array
+     */
+    public function getMovedJobs($batchId, $limit) {
+        $current = $this->loadCurrentState($batchId);
+        $jobs = array_values($current['jobs']);
+        $result = array();
+        foreach ($jobs as $job) {
+            if (isset($job['status']) && $job['status'] === 'moved') {
+                $result[] = $job;
+                if (count($result) >= $limit) {
+                    break;
+                }
+            }
+        }
+        return $result;
+    }
+
+    /**
+     * Finds collapsed manifest rows for multiple review job ids from materialized current state.
+     *
+     * @param string $batchId Batch id.
+     * @param array $reviewIds Review-copy job ids.
+     * @return array Rows keyed by review-copy job id.
+     */
+    public function getJobsByReviewIds($batchId, $reviewIds) {
+        $filter = array();
+        foreach ($reviewIds as $reviewId) {
+            $reviewId = (int)$reviewId;
+            if ($reviewId > 0) {
+                $filter[$reviewId] = true;
+            }
+        }
+        if (!count($filter)) {
+            return array();
+        }
+
+        $result = array();
+        $current = $this->loadCurrentState($batchId);
+        $jobs = $current['jobs'];
+        foreach ($jobs as $job) {
+            if (isset($job['review_id']) && isset($filter[(int)$job['review_id']])) {
+                $result[(int)$job['review_id']] = $job;
+            }
+        }
+        return $result;
+    }
+
+    /**
+     * Returns the audit manifest file path for a batch.
+     *
+     * @param string $batchId Batch id.
+     * @return string
+     */
+    public function getJobsFile($batchId) {
+        return $this->jobsFile($batchId);
+    }
+
+    /**
+     * Returns the batch metadata file path.
+     *
+     * @param string $batchId Batch id.
+     * @return string
+     */
+    public function getBatchFile($batchId) {
+        return $this->batchFile($batchId);
+    }
+
+    /**
+     * Returns the body snapshot file path for a batch.
+     *
+     * @param string $batchId Batch id.
+     * @return string
+     */
+    public function getBodySnapshotFile($batchId) {
+        return $this->bodySnapshotFile($batchId);
+    }
+
+    /**
+     * Returns body snapshot rows keyed by review job id.
+     *
+     * @param string $batchId Batch id.
+     * @param array|null $reviewIds Optional review-copy job ids to load.
+     * @return array
+     */
+    public function getBodySnapshots($batchId, $reviewIds = null) {
+        $file = $this->bodySnapshotFile($batchId);
+        $snapshots = array();
+        $filter = array();
+
+        if (!is_file($file)) {
+            return $snapshots;
+        }
+        if (is_array($reviewIds)) {
+            foreach ($reviewIds as $reviewId) {
+                $filter[(int)$reviewId] = true;
+            }
+            if (!count($filter)) {
+                return $snapshots;
+            }
+            $indexedSnapshots = $this->getBodySnapshotsByIndex($batchId, $filter);
+            if ($indexedSnapshots !== false && count($indexedSnapshots) === count($filter)) {
+                return $indexedSnapshots;
+            }
+        }
+
+        $handle = fopen($file, 'r');
+        if (!$handle) {
+            return $snapshots;
+        }
+
+        while (($line = fgets($handle)) !== false) {
+            $row = $this->decodeBodySnapshotLine($line);
+            if (!is_array($row) || !isset($row['review_id'])) {
+                continue;
+            }
+            $reviewId = (int)$row['review_id'];
+            if ($reviewIds !== null && !isset($filter[$reviewId])) {
+                continue;
+            }
+            $snapshots[$reviewId] = $row;
+            if ($reviewIds !== null) {
+                unset($filter[$reviewId]);
+                if (!count($filter)) {
+                    break;
+                }
+            }
+        }
+
+        fclose($handle);
+        return $snapshots;
+    }
+
+    /**
+     * Deletes all local files associated with a review batch.
+     *
+     * @param string $batchId Batch id.
+     * @return void
+     * @throws InvalidArgumentException If any existing batch file cannot be deleted.
+     */
+    public function deleteBatch($batchId) {
+        $this->deleteFileIfExists($this->operationFile($batchId));
+        $this->deleteFileIfExists($this->bodySnapshotIndexFile($batchId));
+        $this->deleteFileIfExists($this->bodySnapshotFile($batchId));
+        $this->deleteFileIfExists($this->currentStateFile($batchId));
+        $this->deleteFileIfExists($this->jobsFile($batchId));
+        $this->deleteFileIfExists($this->batchFile($batchId));
+        $this->deleteFileIfExists($this->legacyBatchFile($batchId));
+    }
+
+    /**
+     * Saves progress metadata for a long-running review operation.
+     *
+     * @param array $operation Operation metadata.
+     * @return void
+     * @throws InvalidArgumentException If operation metadata cannot be encoded or written.
+     */
+    public function saveOperation($operation) {
+        $this->writeJsonFile($this->operationFile($operation['batch_id']), $operation);
+    }
+
+    /**
+     * Starts a long-running review operation if no other one is processing.
+     *
+     * @param array $operation Operation metadata.
+     * @return void
+     * @throws InvalidArgumentException If another operation is active or operation metadata cannot be saved.
+     */
+    public function startOperation($operation) {
+        $file = $this->operationFile($operation['batch_id']);
+        $handle = fopen($file, 'c+');
+        if (!$handle) {
+            throw new InvalidArgumentException('Review batch operation could not be opened: ' . $file);
+        }
+
+        try {
+            if (!flock($handle, LOCK_EX)) {
+                throw new InvalidArgumentException('Review batch operation could not be locked: ' . $file);
+            }
+            rewind($handle);
+            $contents = stream_get_contents($handle);
+            $existing = $contents !== false && trim($contents) !== '' ? json_decode($contents, true) : false;
+            if ($existing && isset($existing['status']) && $existing['status'] === 'processing') {
+                $owner = isset($existing['owner_ip']) ? $existing['owner_ip'] : 'another session';
+                throw new InvalidArgumentException('Review batch operation is already running by ' . $owner . '.');
+            }
+
+            $data = $this->encodeJson($operation);
+            if (!ftruncate($handle, 0)) {
+                throw new InvalidArgumentException('Review batch operation could not be truncated: ' . $file);
+            }
+            rewind($handle);
+            $this->writeAll($handle, $data, $file);
+            if (!fflush($handle)) {
+                throw new InvalidArgumentException('Review batch operation could not be flushed: ' . $file);
+            }
+            flock($handle, LOCK_UN);
+            fclose($handle);
+        } catch (Exception $e) {
+            flock($handle, LOCK_UN);
+            fclose($handle);
+            throw $e;
+        }
+    }
+
+    /**
+     * Loads progress metadata for a long-running review operation.
+     *
+     * @param string $batchId Batch id.
+     * @return array|false
+     */
+    public function loadOperation($batchId) {
+        $file = $this->operationFile($batchId);
+        if (!is_file($file)) {
+            return false;
+        }
+        return $this->readJsonFile($file);
+    }
+
+    /**
+     * Deletes progress metadata for a long-running review operation.
+     *
+     * @param string $batchId Batch id.
+     * @return void
+     * @throws InvalidArgumentException If operation metadata cannot be deleted.
+     */
+    public function deleteOperation($batchId) {
+        $this->deleteFileIfExists($this->operationFile($batchId));
+    }
+
+    /**
+     * Collapses the append-only audit manifest into the latest row for each reviewed job.
+     *
+     * Normal reads use the materialized current-state file; this only runs when that cache must be rebuilt.
+     *
+     * @param string $batchId Batch id.
+     * @return array
+     */
+    private function readCollapsedJobs($batchId) {
+        $file = $this->jobsFile($batchId);
+        $jobs = array();
+        if (!is_file($file)) {
+            return $jobs;
+        }
+
+        $handle = fopen($file, 'r');
+        if (!$handle) {
+            return $jobs;
+        }
+
+        while (($line = fgets($handle)) !== false) {
+            $line = trim($line);
+            if ($line === '') {
+                continue;
+            }
+            $row = json_decode($line, true);
+            if (!is_array($row)) {
+                continue;
+            }
+            $key = $this->currentStateJobKey($row);
+            if ($key === false) {
+                continue;
+            }
+            if (!isset($jobs[$key])) {
+                $jobs[$key] = array();
+            }
+            $jobs[$key] = array_merge($jobs[$key], $row);
+        }
+        fclose($handle);
+
+        return $jobs;
+    }
+
+    /**
+     * Loads materialized current job state, rebuilding it from audit JSONL when stale or missing.
+     *
+     * @param string $batchId Batch id.
+     * @return array
+     * @throws InvalidArgumentException If current state cannot be rebuilt or saved.
+     */
+    private function loadCurrentState($batchId) {
+        $file = $this->currentStateFile($batchId);
+        $auditSize = $this->getAuditSize($batchId);
+        if (is_file($file)) {
+            $current = $this->readJsonFile($file);
+            if ($this->isValidCurrentState($current, $auditSize)) {
+                return $current;
+            }
+        }
+        return $this->rebuildCurrentState($batchId);
+    }
+
+    /**
+     * Loads current state before appending an audit row.
+     *
+     * @param string $batchId Batch id.
+     * @return array
+     * @throws InvalidArgumentException If current state cannot be rebuilt or saved.
+     */
+    private function loadCurrentStateForAppend($batchId) {
+        return $this->loadCurrentState($batchId);
+    }
+
+    /**
+     * Rebuilds materialized current state from the append-only audit manifest.
+     *
+     * @param string $batchId Batch id.
+     * @return array
+     * @throws InvalidArgumentException If rebuilt state cannot be saved.
+     */
+    private function rebuildCurrentState($batchId) {
+        $current = $this->emptyCurrentState($this->getAuditSize($batchId));
+        $current['jobs'] = $this->readCollapsedJobs($batchId);
+        $this->refreshCurrentStateCounts($current);
+        $current['updated_at'] = date('c');
+        $this->writeCurrentState($batchId, $current);
+        return $current;
+    }
+
+    /**
+     * Applies one audit row to materialized current state.
+     *
+     * @param array $current Current state, modified in place.
+     * @param array $row Audit manifest row.
+     * @return void
+     */
+    private function applyCurrentStateRow(&$current, $row) {
+        $key = $this->currentStateJobKey($row);
+        if ($key === false) {
+            return;
+        }
+
+        $oldStatus = isset($current['jobs'][$key]['status']) ? $current['jobs'][$key]['status'] : null;
+        $isNew = !isset($current['jobs'][$key]);
+        if ($isNew) {
+            $current['jobs'][$key] = array();
+            $current['total'] = (int)$current['total'] + 1;
+        }
+
+        $current['jobs'][$key] = array_merge($current['jobs'][$key], $row);
+        $newStatus = isset($current['jobs'][$key]['status']) ? $current['jobs'][$key]['status'] : null;
+        if ($oldStatus === 'moved' && $newStatus !== 'moved') {
+            $current['moved_count'] = max(0, (int)$current['moved_count'] - 1);
+        } elseif ($oldStatus !== 'moved' && $newStatus === 'moved') {
+            $current['moved_count'] = (int)$current['moved_count'] + 1;
+        }
+    }
+
+    /**
+     * Recomputes current state aggregate counts from jobs.
+     *
+     * @param array $current Current state, modified in place.
+     * @return void
+     */
+    private function refreshCurrentStateCounts(&$current) {
+        $current['total'] = count($current['jobs']);
+        $current['moved_count'] = 0;
+        foreach ($current['jobs'] as $job) {
+            if (isset($job['status']) && $job['status'] === 'moved') {
+                $current['moved_count'] = (int)$current['moved_count'] + 1;
+            }
+        }
+    }
+
+    /**
+     * Builds an empty materialized current state document.
+     *
+     * @param int $auditSize Current audit manifest file size.
+     * @return array
+     */
+    private function emptyCurrentState($auditSize) {
+        return array(
+            'version' => 1,
+            'audit_size' => (int)$auditSize,
+            'total' => 0,
+            'moved_count' => 0,
+            'jobs' => array(),
+            'updated_at' => date('c'),
+        );
+    }
+
+    /**
+     * Checks whether a materialized current state document matches the audit file and its own counts.
+     *
+     * @param mixed $current Decoded current state.
+     * @param int $auditSize Current audit manifest file size.
+     * @return bool
+     */
+    private function isValidCurrentState($current, $auditSize) {
+        if (!is_array($current)
+                || !isset($current['version'], $current['audit_size'], $current['total'], $current['moved_count'], $current['jobs'])
+                || (int)$current['version'] !== 1
+                || (int)$current['audit_size'] !== (int)$auditSize
+                || !is_array($current['jobs'])) {
+            return false;
+        }
+
+        $movedCount = 0;
+        foreach ($current['jobs'] as $job) {
+            if (is_array($job) && isset($job['status']) && $job['status'] === 'moved') {
+                $movedCount++;
+            }
+        }
+
+        return (int)$current['total'] === count($current['jobs'])
+                && (int)$current['moved_count'] === $movedCount;
+    }
+
+    /**
+     * Writes materialized current state.
+     *
+     * @param string $batchId Batch id.
+     * @param array $current Current state.
+     * @return void
+     * @throws InvalidArgumentException If current state cannot be written.
+     */
+    private function writeCurrentState($batchId, $current) {
+        $this->writeJsonFile($this->currentStateFile($batchId), $current);
+    }
+
+    /**
+     * Returns current audit manifest file size.
+     *
+     * @param string $batchId Batch id.
+     * @return int
+     */
+    private function getAuditSize($batchId) {
+        $file = $this->jobsFile($batchId);
+        clearstatcache(true, $file);
+        return is_file($file) ? (int)filesize($file) : 0;
+    }
+
+    /**
+     * Builds the current-state key for one audit row.
+     *
+     * @param array $row Audit manifest row.
+     * @return string|false
+     */
+    private function currentStateJobKey($row) {
+        if (isset($row['original_id'])) {
+            return 'o:' . $row['original_id'];
+        }
+        if (isset($row['review_id'])) {
+            return 'r:' . $row['review_id'];
+        }
+        return false;
+    }
+
+    /**
+     * Reads requested body snapshot rows by byte offset when the sidecar index is available.
+     *
+     * @param string $batchId Batch id.
+     * @param array $filter Review-copy job ids keyed by id.
+     * @return array|false
+     */
+    private function getBodySnapshotsByIndex($batchId, $filter) {
+        $indexFile = $this->bodySnapshotIndexFile($batchId);
+        $snapshotFile = $this->bodySnapshotFile($batchId);
+        $index = array();
+        $snapshots = array();
+
+        if (!is_file($indexFile) || !is_file($snapshotFile)) {
+            return false;
+        }
+
+        $indexHandle = fopen($indexFile, 'r');
+        if (!$indexHandle) {
+            return false;
+        }
+        while (($line = fgets($indexHandle)) !== false) {
+            $row = json_decode($line, true);
+            if (!is_array($row) || !isset($row['review_id'], $row['offset'], $row['length'])) {
+                continue;
+            }
+            $reviewId = (int)$row['review_id'];
+            if (isset($filter[$reviewId])) {
+                $index[$reviewId] = array(
+                    'review_id' => $reviewId,
+                    'offset' => (int)$row['offset'],
+                    'length' => (int)$row['length'],
+                );
+            }
+        }
+        fclose($indexHandle);
+
+        if (count($index) !== count($filter)) {
+            return false;
+        }
+
+        uasort($index, array($this, 'sortSnapshotOffsetsAscending'));
+        $snapshotHandle = fopen($snapshotFile, 'rb');
+        if (!$snapshotHandle) {
+            return false;
+        }
+
+        foreach ($index as $entry) {
+            if (fseek($snapshotHandle, $entry['offset']) !== 0) {
+                fclose($snapshotHandle);
+                return false;
+            }
+            $line = fgets($snapshotHandle, $entry['length'] + 1);
+            if ($line === false) {
+                fclose($snapshotHandle);
+                return false;
+            }
+            $row = $this->decodeBodySnapshotLine($line);
+            if (!is_array($row) || !isset($row['review_id'])) {
+                fclose($snapshotHandle);
+                return false;
+            }
+            $snapshots[(int)$row['review_id']] = $row;
+        }
+
+        fclose($snapshotHandle);
+        return $snapshots;
+    }
+
+    /**
+     * Decodes one body snapshot JSONL row and normalizes the body field.
+     *
+     * @param string $line JSONL row.
+     * @return array|false
+     */
+    private function decodeBodySnapshotLine($line) {
+        $row = json_decode($line, true);
+        if (!is_array($row) || !isset($row['review_id'])) {
+            return false;
+        }
+        $body = '';
+        if (isset($row['body_encoding']) && $row['body_encoding'] === 'base64' && isset($row['body_base64'])) {
+            $decoded = base64_decode($row['body_base64'], true);
+            $body = $decoded === false ? '' : $decoded;
+        } elseif (isset($row['body'])) {
+            $body = $row['body'];
+        }
+        $row['body'] = $body;
+        return $row;
+    }
+
+    /**
+     * Writes one JSON document atomically enough for this file-based storage.
+     *
+     * @param string $file Destination file path.
+     * @param mixed $data JSON-serializable data.
+     * @return void
+     * @throws InvalidArgumentException If the data cannot be encoded or written.
+     */
+    private function writeJsonFile($file, $data) {
+        $this->writeFile($file, $this->encodeJson($data));
+    }
+
+    /**
+     * Reads one JSON document from disk.
+     *
+     * @param string $file Source file path.
+     * @return mixed
+     */
+    private function readJsonFile($file) {
+        return json_decode(file_get_contents($file), true);
+    }
+
+    /**
+     * Encodes JSON and fails loudly when data cannot be represented.
+     *
+     * @param mixed $data JSON-serializable data.
+     * @return string
+     * @throws InvalidArgumentException If JSON encoding fails.
+     */
+    private function encodeJson($data) {
+        $json = json_encode($data);
+        if ($json === false) {
+            $message = function_exists('json_last_error_msg') ? json_last_error_msg() : 'JSON encode failed';
+            throw new InvalidArgumentException($message);
+        }
+        return $json;
+    }
+
+    /**
+     * Appends file contents and checks that all bytes were written.
+     *
+     * @param string $file Destination file path.
+     * @param string $data Data to append.
+     * @return void
+     * @throws InvalidArgumentException If the append fails or writes only part of the data.
+     */
+    private function appendFile($file, $data) {
+        $result = file_put_contents($file, $data, FILE_APPEND | LOCK_EX);
+        if ($result === false || $result !== strlen($data)) {
+            throw new InvalidArgumentException('Could not append review batch file: ' . $file);
+        }
+    }
+
+    /**
+     * Writes file contents through a temporary file and rename.
+     *
+     * @param string $file Destination file path.
+     * @param string $data Data to write.
+     * @return void
+     * @throws InvalidArgumentException If the temporary write or rename fails.
+     */
+    private function writeFile($file, $data) {
+        $tmp = $file . '.tmp';
+        $result = file_put_contents($tmp, $data, LOCK_EX);
+        if ($result === false || $result !== strlen($data)) {
+            throw new InvalidArgumentException('Could not write review batch file: ' . $tmp);
+        }
+        if (!rename($tmp, $file)) {
+            if (is_file($tmp)) {
+                @unlink($tmp);
+            }
+            throw new InvalidArgumentException('Could not move review batch file into place: ' . $file);
+        }
+    }
+
+    /**
+     * Writes a full string to an open file handle.
+     *
+     * @param resource $handle Open file handle.
+     * @param string $data Data to write.
+     * @param string $file Destination file path for error reporting.
+     * @return void
+     * @throws InvalidArgumentException If the full string cannot be written.
+     */
+    private function writeAll($handle, $data, $file) {
+        $written = 0;
+        $length = strlen($data);
+        while ($written < $length) {
+            $result = fwrite($handle, substr($data, $written));
+            if ($result === false || $result === 0) {
+                throw new InvalidArgumentException('Could not write review batch file: ' . $file);
+            }
+            $written += $result;
+        }
+    }
+
+    /**
+     * Deletes one file when it exists.
+     *
+     * @param string $file File path.
+     * @return void
+     * @throws InvalidArgumentException If the file still exists after deletion is attempted.
+     */
+    private function deleteFileIfExists($file) {
+        if (is_file($file) && !@unlink($file) && is_file($file)) {
+            throw new InvalidArgumentException('Review batch file could not be deleted: ' . $file);
+        }
+    }
+
+    /**
+     * Builds the batch metadata path for a batch id.
+     *
+     * @param string $id Batch id.
+     * @return string
+     */
+    private function batchFile($id) {
+        return $this->path . DIRECTORY_SEPARATOR . $this->sanitizeId($id) . '.batch.json';
+    }
+
+    /**
+     * Builds the legacy batch metadata path used before batch files had a type suffix.
+     *
+     * @param string $id Batch id.
+     * @return string
+     */
+    private function legacyBatchFile($id) {
+        return $this->path . DIRECTORY_SEPARATOR . $this->sanitizeId($id) . '.json';
+    }
+
+    /**
+     * Builds the audit manifest path for a batch id.
+     *
+     * @param string $id Batch id.
+     * @return string
+     */
+    private function jobsFile($id) {
+        return $this->path . DIRECTORY_SEPARATOR . $this->sanitizeId($id) . '.jobs.jsonl';
+    }
+
+    /**
+     * Builds the materialized current-state path for a batch id.
+     *
+     * @param string $id Batch id.
+     * @return string
+     */
+    private function currentStateFile($id) {
+        return $this->path . DIRECTORY_SEPARATOR . $this->sanitizeId($id) . '.current.json';
+    }
+
+    /**
+     * Builds the operation metadata path for a batch id.
+     *
+     * @param string $id Batch id.
+     * @return string
+     */
+    private function operationFile($id) {
+        return $this->path . DIRECTORY_SEPARATOR . $this->sanitizeId($id) . '.operation.json';
+    }
+
+    /**
+     * Builds the body snapshot path for a batch id.
+     *
+     * @param string $id Batch id.
+     * @return string
+     */
+    private function bodySnapshotFile($id) {
+        return $this->path . DIRECTORY_SEPARATOR . $this->sanitizeId($id) . '.body-snapshot.jsonl';
+    }
+
+    /**
+     * Builds the body snapshot byte-offset index path for a batch id.
+     *
+     * @param string $id Batch id.
+     * @return string
+     */
+    private function bodySnapshotIndexFile($id) {
+        return $this->path . DIRECTORY_SEPARATOR . $this->sanitizeId($id) . '.body-snapshot.idx.jsonl';
+    }
+
+    /**
+     * Makes a batch id safe for use as a file name.
+     *
+     * @param string $id Batch id.
+     * @return string
+     */
+    private function sanitizeId($id) {
+        return preg_replace('/[^A-Za-z0-9_.-]/', '_', $id);
+    }
+
+    /**
+     * Sort callback that presents newest review batches first.
+     *
+     * @param array $a First batch metadata row.
+     * @param array $b Second batch metadata row.
+     * @return int
+     */
+    private function sortBatchesNewestFirst($a, $b) {
+        $aCreated = isset($a['created_at']) ? $a['created_at'] : '';
+        $bCreated = isset($b['created_at']) ? $b['created_at'] : '';
+        return strcmp($bCreated, $aCreated);
+    }
+
+    /**
+     * Sort callback that reads snapshot rows in file order.
+     *
+     * @param array $a First index row.
+     * @param array $b Second index row.
+     * @return int
+     */
+    private function sortSnapshotOffsetsAscending($a, $b) {
+        if ($a['offset'] === $b['offset']) {
+            return 0;
+        }
+        return $a['offset'] < $b['offset'] ? -1 : 1;
+    }
+}

--- a/tests/review_batch_naming_test.php
+++ b/tests/review_batch_naming_test.php
@@ -1,0 +1,21 @@
+<?php
+
+require_once dirname(__FILE__) . '/../src/ReviewBatchNaming.php';
+
+function assertNamingSame($expected, $actual, $message) {
+    if ($expected !== $actual) {
+        throw new Exception($message . ' Expected ' . var_export($expected, true) . ', got ' . var_export($actual, true));
+    }
+}
+
+try {
+    assertNamingSame('emails.REVIEW.20260619-120000', ReviewBatchNaming::defaultReviewTube('emails', '20260619-120000'), 'Default review tube should keep source tube first');
+    assertNamingSame('tube_with_spaces.REVIEW.abc_123', ReviewBatchNaming::defaultReviewTube('tube with spaces', 'abc 123'), 'Default review tube should sanitize source and suffix');
+    assertNamingSame('tube.name-1_REVIEW', ReviewBatchNaming::sanitizeTubePart('tube.name-1 REVIEW'), 'Tube-name parts should preserve established safe characters');
+
+    echo "ReviewBatchNaming tests passed.\n";
+} catch (Exception $e) {
+    fwrite(STDERR, $e->getMessage() . "\n");
+    exit(1);
+}
+

--- a/tests/review_batch_page_builder_test.php
+++ b/tests/review_batch_page_builder_test.php
@@ -71,6 +71,7 @@ class ReviewBatchPageBuilderFakeInterface {
 
 class ReviewBatchPageBuilderFakeStorage {
     public $updates = array();
+    public $snapshotCalls = 0;
     private $jobs;
     private $snapshots;
 
@@ -107,6 +108,7 @@ class ReviewBatchPageBuilderFakeStorage {
     }
 
     public function getBodySnapshots($batchId, $reviewIds = null) {
+        $this->snapshotCalls++;
         if ($reviewIds === null) {
             return $this->snapshots;
         }
@@ -153,6 +155,18 @@ try {
     assertPageSame(0, $client->peekCalls, 'Snapshot body should not peek the live review job');
 
     $builder = makeReviewPageBuilder(
+        array(array('original_id' => 5, 'review_id' => 105, 'status' => 'moved')),
+        array(105 => array('body' => 'disabled snapshot should not load')),
+        array(105 => 'live body when snapshots disabled'),
+        $storage,
+        $client
+    );
+    $page = $builder->buildShowPage(array('id' => 'batch-1', 'include_body_snapshot' => false), 1, 25, 50);
+    assertPageSame('live', $page['reviewJobBodies'][105]['body_source'], 'Disabled snapshots should use the live review job');
+    assertPageSame(0, $storage->snapshotCalls, 'Disabled snapshots should not read body snapshot storage');
+    assertPageSame(1, $client->peekCalls, 'Disabled snapshots should peek the live review job');
+
+    $builder = makeReviewPageBuilder(
         array(array('original_id' => 2, 'review_id' => 102, 'status' => 'moved')),
         array(),
         array(102 => 'live body abc'),
@@ -189,6 +203,7 @@ try {
     assertPageSame(0, $page['reviewPageSelectableCount'], 'Missing review jobs should refresh selectable counts');
 
     assertPageTrue($builder->reviewJobHasInspectableCopy(array('status' => 'return_delete_error', 'review_id' => 105)), 'Cleanup rows should be inspectable');
+    assertPageTrue($builder->reviewJobHasInspectableCopy(array('status' => 'duplicated', 'review_id' => 107)), 'Duplicated rows should keep their review copy inspectable');
     assertPageTrue(!$builder->reviewJobHasInspectableCopy(array('status' => 'returned', 'review_id' => 106)), 'Returned rows should not be inspectable');
     assertPageSame('abc', $builder->truncateReviewBody('abc', 3), 'Exact-length previews should not be truncated');
     assertPageSame('abc...', $builder->truncateReviewBody('abcdef', 3), 'Long previews should be truncated');

--- a/tests/review_batch_page_builder_test.php
+++ b/tests/review_batch_page_builder_test.php
@@ -1,0 +1,201 @@
+<?php
+
+if (!class_exists('Pheanstalk_Response')) {
+    class Pheanstalk_Response {
+        const RESPONSE_NOT_FOUND = 'NOT_FOUND';
+    }
+}
+
+require_once dirname(__FILE__) . '/../src/Settings.php';
+require_once dirname(__FILE__) . '/../src/ReviewBatchPageBuilder.php';
+
+$GLOBALS['config'] = array(
+    'settings' => array(
+        'enableJsonDecode' => false,
+        'enableUnserialization' => false,
+        'enableBase64Decode' => false,
+    ),
+);
+
+function assertPageSame($expected, $actual, $message) {
+    if ($expected !== $actual) {
+        throw new Exception($message . ' Expected ' . var_export($expected, true) . ', got ' . var_export($actual, true));
+    }
+}
+
+function assertPageTrue($value, $message) {
+    if (!$value) {
+        throw new Exception($message);
+    }
+}
+
+class ReviewBatchPageBuilderFakeJob {
+    private $data;
+
+    public function __construct($data) {
+        $this->data = $data;
+    }
+
+    public function getData() {
+        return $this->data;
+    }
+}
+
+class ReviewBatchPageBuilderFakeClient {
+    public $peekCalls = 0;
+    private $responses;
+
+    public function __construct($responses) {
+        $this->responses = $responses;
+    }
+
+    public function peek($id) {
+        $this->peekCalls++;
+        if (!array_key_exists($id, $this->responses)) {
+            return false;
+        }
+        if ($this->responses[$id] instanceof Exception) {
+            throw $this->responses[$id];
+        }
+        return new ReviewBatchPageBuilderFakeJob($this->responses[$id]);
+    }
+}
+
+class ReviewBatchPageBuilderFakeInterface {
+    public $_client;
+
+    public function __construct($client) {
+        $this->_client = $client;
+    }
+}
+
+class ReviewBatchPageBuilderFakeStorage {
+    public $updates = array();
+    private $jobs;
+    private $snapshots;
+
+    public function __construct($jobs, $snapshots) {
+        $this->jobs = $jobs;
+        $this->snapshots = $snapshots;
+    }
+
+    public function loadOperation($batchId) {
+        return false;
+    }
+
+    public function getBatchSummary($batchId, $offset = 0, $limit = null) {
+        $jobs = array_values($this->jobs);
+        $pageJobs = $limit === null ? array_slice($jobs, $offset) : array_slice($jobs, $offset, $limit);
+        $movedCount = 0;
+        $pageSelectableCount = 0;
+        foreach ($jobs as $job) {
+            if (isset($job['status']) && $job['status'] === 'moved') {
+                $movedCount++;
+            }
+        }
+        foreach ($pageJobs as $job) {
+            if (isset($job['status'], $job['review_id']) && $job['status'] === 'moved' && (int)$job['review_id'] > 0) {
+                $pageSelectableCount++;
+            }
+        }
+        return array(
+            'jobs' => $pageJobs,
+            'total' => count($jobs),
+            'moved_count' => $movedCount,
+            'page_selectable_count' => $pageSelectableCount,
+        );
+    }
+
+    public function getBodySnapshots($batchId, $reviewIds = null) {
+        if ($reviewIds === null) {
+            return $this->snapshots;
+        }
+        $result = array();
+        foreach ($reviewIds as $reviewId) {
+            if (isset($this->snapshots[$reviewId])) {
+                $result[$reviewId] = $this->snapshots[$reviewId];
+            }
+        }
+        return $result;
+    }
+
+    public function updateJob($batchId, $row) {
+        $this->updates[] = $row;
+        foreach ($this->jobs as $index => $job) {
+            if (isset($job['review_id'], $row['review_id']) && (int)$job['review_id'] === (int)$row['review_id']) {
+                $this->jobs[$index] = array_merge($job, $row);
+                return;
+            }
+        }
+        $this->jobs[] = $row;
+    }
+}
+
+function makeReviewPageBuilder($jobs, $snapshots, $responses, &$storage, &$client) {
+    $storage = new ReviewBatchPageBuilderFakeStorage($jobs, $snapshots);
+    $client = new ReviewBatchPageBuilderFakeClient($responses);
+    return new ReviewBatchPageBuilder(new ReviewBatchPageBuilderFakeInterface($client), $storage);
+}
+
+$batch = array('id' => 'batch-1', 'include_body_snapshot' => true);
+
+try {
+    $builder = makeReviewPageBuilder(
+        array(array('original_id' => 1, 'review_id' => 101, 'status' => 'moved')),
+        array(101 => array('body' => 'snapshot body abc')),
+        array(101 => 'live body should not load'),
+        $storage,
+        $client
+    );
+    $page = $builder->buildShowPage($batch, 1, 25, 8);
+    assertPageSame('snapshot', $page['reviewJobBodies'][101]['body_source'], 'Snapshot body should be preferred');
+    assertPageSame('snapshot...', $page['reviewJobPreviews'][101], 'Snapshot preview should be truncated');
+    assertPageSame(0, $client->peekCalls, 'Snapshot body should not peek the live review job');
+
+    $builder = makeReviewPageBuilder(
+        array(array('original_id' => 2, 'review_id' => 102, 'status' => 'moved')),
+        array(),
+        array(102 => 'live body abc'),
+        $storage,
+        $client
+    );
+    $page = $builder->buildShowPage(array('id' => 'batch-1'), 1, 25, 50);
+    assertPageSame('live', $page['reviewJobBodies'][102]['body_source'], 'Live body should be used when no snapshot exists');
+    assertPageSame('live body abc', $page['reviewJobBodies'][102]['body'], 'Live body should be rendered in full');
+    assertPageSame(1, $client->peekCalls, 'Live fallback should peek once');
+
+    $builder = makeReviewPageBuilder(
+        array(array('original_id' => 3, 'review_id' => 103, 'status' => 'moved')),
+        array(),
+        array(103 => new Exception('temporary failure')),
+        $storage,
+        $client
+    );
+    $page = $builder->buildShowPage(array('id' => 'batch-1'), 1, 25, 100);
+    assertPageSame('error', $page['reviewJobBodies'][103]['body_source'], 'Generic body load errors should render an error body');
+    assertPageTrue(strpos($page['reviewJobBodies'][103]['body'], 'Unable to load review body: temporary failure') === 0, 'Generic error message should be visible');
+
+    $builder = makeReviewPageBuilder(
+        array(array('original_id' => 4, 'review_id' => 104, 'status' => 'moved')),
+        array(),
+        array(104 => new Exception(Pheanstalk_Response::RESPONSE_NOT_FOUND)),
+        $storage,
+        $client
+    );
+    $page = $builder->buildShowPage(array('id' => 'batch-1'), 1, 25, 100);
+    assertPageSame('missing_review_job', $page['reviewJobs'][0]['status'], 'Missing review jobs should be reconciled into page rows');
+    assertPageSame(1, count($storage->updates), 'Missing review jobs should append one manifest update');
+    assertPageSame(0, $page['reviewRemainingMovedCount'], 'Missing review jobs should refresh moved counts');
+    assertPageSame(0, $page['reviewPageSelectableCount'], 'Missing review jobs should refresh selectable counts');
+
+    assertPageTrue($builder->reviewJobHasInspectableCopy(array('status' => 'return_delete_error', 'review_id' => 105)), 'Cleanup rows should be inspectable');
+    assertPageTrue(!$builder->reviewJobHasInspectableCopy(array('status' => 'returned', 'review_id' => 106)), 'Returned rows should not be inspectable');
+    assertPageSame('abc', $builder->truncateReviewBody('abc', 3), 'Exact-length previews should not be truncated');
+    assertPageSame('abc...', $builder->truncateReviewBody('abcdef', 3), 'Long previews should be truncated');
+    assertPageSame('minutes: 1<br>seconds: 5', $builder->formatDuration(65), 'Duration helper should match existing display format');
+
+    echo "ReviewBatchPageBuilder tests passed.\n";
+} catch (Exception $e) {
+    fwrite(STDERR, $e->getMessage() . "\n");
+    exit(1);
+}

--- a/tests/review_batch_service_test.php
+++ b/tests/review_batch_service_test.php
@@ -1,0 +1,261 @@
+<?php
+
+require_once dirname(__FILE__) . '/../lib/Pheanstalk.php';
+require_once dirname(__FILE__) . '/../src/ReviewBatchService.php';
+
+if (!class_exists('Pheanstalk_Response')) {
+    class Pheanstalk_Response {
+        const RESPONSE_NOT_FOUND = 'NOT_FOUND';
+    }
+}
+
+class ReviewBatchServiceFakeJob {
+    private $id;
+    private $data;
+
+    public function __construct($id, $data) {
+        $this->id = $id;
+        $this->data = $data;
+    }
+
+    public function getId() {
+        return $this->id;
+    }
+
+    public function getData() {
+        return $this->data;
+    }
+}
+
+class ReviewBatchServiceFakeClient {
+    public $jobs = array();
+    public $readyJobs = array();
+    public $delayedJobs = array();
+    public $buriedJobs = array();
+    public $stats = array();
+    public $deleted = array();
+    public $deleteExceptions = array();
+    public $peekExceptions = array();
+    public $events = array();
+    public $usedTube = null;
+
+    public function useTube($tube) {
+        $this->usedTube = $tube;
+        return $this;
+    }
+
+    public function peekReady() {
+        return $this->shiftStateJob($this->readyJobs);
+    }
+
+    public function peekDelayed() {
+        return $this->shiftStateJob($this->delayedJobs);
+    }
+
+    public function peekBuried() {
+        return $this->shiftStateJob($this->buriedJobs);
+    }
+
+    public function peek($id) {
+        $id = (int)$id;
+        $this->events[] = 'peek:' . $id;
+        if (isset($this->peekExceptions[$id])) {
+            throw $this->peekExceptions[$id];
+        }
+        if (!isset($this->jobs[$id])) {
+            throw new Exception(Pheanstalk_Response::RESPONSE_NOT_FOUND);
+        }
+        return $this->jobs[$id];
+    }
+
+    public function statsJob($job) {
+        $id = (int)$job->getId();
+        $this->events[] = 'stats:' . $id;
+        return isset($this->stats[$id]) ? $this->stats[$id] : array();
+    }
+
+    public function delete($job) {
+        $id = (int)$job->getId();
+        $this->events[] = 'delete:' . $id;
+        if (isset($this->deleteExceptions[$id])) {
+            throw $this->deleteExceptions[$id];
+        }
+        $this->deleted[] = $id;
+    }
+
+    private function shiftStateJob(&$jobs) {
+        if (!count($jobs)) {
+            throw new Exception(Pheanstalk_Response::RESPONSE_NOT_FOUND);
+        }
+        $job = array_shift($jobs);
+        $this->events[] = 'peek-state:' . $job->getId();
+        return $job;
+    }
+}
+
+class ReviewBatchServiceFakeInterface {
+    public $_client;
+    public $added = array();
+    public $addExceptions = array();
+    private $nextId = 900;
+
+    public function __construct($client) {
+        $this->_client = $client;
+    }
+
+    public function addJob($tubeName, $tubeData, $tubePriority = Pheanstalk::DEFAULT_PRIORITY, $tubeDelay = Pheanstalk::DEFAULT_DELAY, $tubeTtr = Pheanstalk::DEFAULT_TTR) {
+        $this->_client->events[] = 'add:' . $tubeName;
+        if (count($this->addExceptions)) {
+            throw array_shift($this->addExceptions);
+        }
+        $this->nextId++;
+        $this->added[] = array($tubeName, $tubeData, $tubePriority, $tubeDelay, $tubeTtr, $this->nextId);
+        return $this->nextId;
+    }
+}
+
+class ReviewBatchServiceFakeStorage {
+    public $updates = array();
+    public $appended = array();
+    public $bodySnapshots = array();
+    public $savedBatches = array();
+
+    public function updateJob($batchId, $row) {
+        $this->updates[] = array($batchId, $row);
+    }
+
+    public function appendJob($batchId, $row) {
+        $this->appended[] = array($batchId, $row);
+    }
+
+    public function appendBodySnapshotRows($batchId, $rows) {
+        $this->bodySnapshots[] = array($batchId, $rows);
+    }
+
+    public function saveBatch($batch) {
+        $this->savedBatches[] = $batch;
+    }
+}
+
+function assertServiceSame($expected, $actual, $message) {
+    if ($expected !== $actual) {
+        throw new Exception($message . ': expected ' . var_export($expected, true) . ', got ' . var_export($actual, true));
+    }
+}
+
+function assertServiceTrue($value, $message) {
+    if (!$value) {
+        throw new Exception($message);
+    }
+}
+
+function makeReviewBatchService(&$client, &$storage, &$interface) {
+    $client = new ReviewBatchServiceFakeClient();
+    $storage = new ReviewBatchServiceFakeStorage();
+    $interface = new ReviewBatchServiceFakeInterface($client);
+    return new ReviewBatchService($interface, $storage);
+}
+
+try {
+    $service = makeReviewBatchService($client, $storage, $interface);
+    $client->jobs[101] = new ReviewBatchServiceFakeJob(101, 'payload');
+    $batch = array('id' => 'batch-1', 'source_tube' => 'source');
+    $manifestJob = array('original_id' => 1, 'review_id' => 101, 'pri' => 5, 'ttr' => 60);
+
+    $result = $service->operateReviewJob($batch, $manifestJob, array('operation' => 'move_all_moved', 'target_tube' => 'source', 'delay' => 7));
+    assertServiceSame(true, $result, 'Moving to source should succeed');
+    assertServiceSame('returned', $storage->updates[0][1]['status'], 'Moving to source should be recorded as returned');
+    assertServiceSame('source', $interface->added[0][0], 'Moving to source should add to source tube');
+    assertServiceSame(5, $interface->added[0][2], 'Move should preserve priority');
+    assertServiceSame(7, $interface->added[0][3], 'Move should use requested delay');
+    assertServiceSame(60, $interface->added[0][4], 'Move should preserve TTR');
+    assertServiceSame(array(101), $client->deleted, 'Move should delete the review copy');
+
+    $client->jobs[102] = new ReviewBatchServiceFakeJob(102, 'payload2');
+    $manifestJob = array('original_id' => 2, 'review_id' => 102, 'pri' => 6, 'ttr' => 120);
+    $service->operateReviewJob($batch, $manifestJob, array('operation' => 'move_all_moved', 'target_tube' => 'other', 'delay' => 0));
+    assertServiceSame('moved_to_tube', $storage->updates[1][1]['status'], 'Moving to another tube should be recorded as moved_to_tube');
+    assertServiceSame('other', $storage->updates[1][1]['target_tube'], 'Moved rows should record target tube');
+
+    $client->jobs[103] = new ReviewBatchServiceFakeJob(103, 'payload3');
+    $manifestJob = array('original_id' => 3, 'review_id' => 103, 'pri' => 7, 'ttr' => 180);
+    $service->operateReviewJob($batch, $manifestJob, array('operation' => 'duplicate_all_moved', 'target_tube' => 'copy', 'delay' => 0));
+    assertServiceSame('duplicated', $storage->updates[2][1]['status'], 'Duplicate should be recorded as duplicated');
+    assertServiceSame(array(101, 102), $client->deleted, 'Duplicate should leave the review copy in place');
+
+    $client->jobs[104] = new ReviewBatchServiceFakeJob(104, 'payload4');
+    $manifestJob = array('original_id' => 4, 'review_id' => 104);
+    $service->operateReviewJob($batch, $manifestJob, array('operation' => 'delete_all_moved'));
+    assertServiceSame('deleted', $storage->updates[3][1]['status'], 'Delete should be recorded as deleted');
+    assertServiceSame(array(101, 102, 104), $client->deleted, 'Delete should remove the review copy');
+
+    $manifestJob = array('original_id' => 5, 'review_id' => 105);
+    $service->operateReviewJob($batch, $manifestJob, array('operation' => 'move_all_moved', 'target_tube' => 'source'));
+    assertServiceSame('missing_review_job', $storage->updates[4][1]['status'], 'Missing review copy should block moves');
+
+    $manifestJob = array('original_id' => 6, 'review_id' => 106);
+    $service->operateReviewJob($batch, $manifestJob, array('operation' => 'delete_all_moved'));
+    assertServiceSame('deleted', $storage->updates[5][1]['status'], 'Missing review copy should count as deleted for delete operations');
+
+    $client->jobs[107] = new ReviewBatchServiceFakeJob(107, 'payload7');
+    $client->deleteExceptions[107] = new Exception('delete failed');
+    $manifestJob = array('original_id' => 7, 'review_id' => 107, 'pri' => 1, 'ttr' => 30);
+    $result = $service->operateReviewJob($batch, $manifestJob, array('operation' => 'move_all_moved', 'target_tube' => 'elsewhere', 'delay' => 3));
+    assertServiceSame(false, $result, 'Move should report failure when review cleanup fails');
+    assertServiceSame('move_delete_error', $storage->updates[6][1]['status'], 'Move cleanup failure should keep review copy visible');
+    assertServiceSame('elsewhere', $storage->updates[6][1]['target_tube'], 'Move cleanup failure should record destination tube');
+    assertServiceTrue(isset($storage->updates[6][1]['target_id']), 'Move cleanup failure should record created destination id');
+
+    $service = makeReviewBatchService($client, $storage, $interface);
+    $sourceJob = new ReviewBatchServiceFakeJob(201, 'source payload');
+    $client->readyJobs[] = $sourceJob;
+    $client->stats[201] = array('pri' => 9, 'ttr' => 45, 'age' => 12);
+    $batch = array(
+        'id' => 'prep-1',
+        'source_tube' => 'source',
+        'source_state' => 'ready',
+        'review_tube' => 'source.REVIEW.1',
+        'target_count' => 1,
+        'processed' => 0,
+        'errors' => 0,
+        'status' => 'processing',
+        'include_body_snapshot' => 1,
+    );
+    $result = $service->processPreparationChunk($batch, 5);
+    assertServiceSame('complete', $result['status'], 'Preparation should complete after target count is reached');
+    assertServiceSame(1, $result['processed'], 'Preparation should increment processed count');
+    assertServiceSame('source.REVIEW.1', $interface->added[0][0], 'Preparation should add to review tube');
+    assertServiceSame(array('peek-state:201', 'stats:201', 'add:source.REVIEW.1', 'delete:201'), $client->events, 'Preparation should copy before deleting the source job');
+    assertServiceSame('moved', $storage->appended[0][1]['status'], 'Preparation should append moved audit row');
+    assertServiceSame('snapshot', $storage->bodySnapshots[0][1][0]['status'], 'Preparation should append body snapshot row when enabled');
+    assertServiceSame(base64_encode('source payload'), $storage->bodySnapshots[0][1][0]['body_base64'], 'Body snapshot should store base64 body');
+
+    $service = makeReviewBatchService($client, $storage, $interface);
+    $sourceJob = new ReviewBatchServiceFakeJob(202, 'delete fails payload');
+    $client->buriedJobs[] = $sourceJob;
+    $client->stats[202] = array('pri' => 10, 'ttr' => 60);
+    $client->deleteExceptions[202] = new Exception('source delete failed');
+    $batch = array(
+        'id' => 'prep-2',
+        'source_tube' => 'source',
+        'source_state' => 'buried',
+        'review_tube' => 'source.REVIEW.2',
+        'target_count' => 2,
+        'processed' => 0,
+        'errors' => 0,
+        'status' => 'processing',
+        'include_body_snapshot' => 1,
+    );
+    $result = $service->processPreparationChunk($batch, 5);
+    assertServiceSame('error', $result['status'], 'Preparation should stop on source delete failure');
+    assertServiceSame(1, $result['errors'], 'Preparation should increment error count');
+    assertServiceSame(0, $result['processed'], 'Failed source cleanup should not count as processed');
+    assertServiceSame('copy_delete_error', $storage->appended[0][1]['status'], 'Preparation should record copy_delete_error when review copy exists');
+    assertServiceSame('source delete failed', $storage->appended[0][1]['error_message'], 'Preparation should record delete failure message');
+    assertServiceSame(array('peek-state:202', 'stats:202', 'add:source.REVIEW.2', 'delete:202'), $client->events, 'Failed preparation should still copy before delete attempt');
+
+    echo "ReviewBatchService tests passed.\n";
+} catch (Exception $e) {
+    fwrite(STDERR, $e->getMessage() . "\n");
+    exit(1);
+}

--- a/tests/review_batch_storage_current_state_test.php
+++ b/tests/review_batch_storage_current_state_test.php
@@ -1,0 +1,144 @@
+<?php
+
+require_once dirname(__FILE__) . '/../src/ReviewBatchStorage.php';
+
+function assertSameValue($expected, $actual, $message) {
+    if ($expected !== $actual) {
+        throw new Exception($message . ' Expected ' . var_export($expected, true) . ', got ' . var_export($actual, true));
+    }
+}
+
+function assertTrueValue($value, $message) {
+    if (!$value) {
+        throw new Exception($message);
+    }
+}
+
+function removeTree($path) {
+    if (!is_dir($path)) {
+        return;
+    }
+    $items = scandir($path);
+    foreach ($items as $item) {
+        if ($item === '.' || $item === '..') {
+            continue;
+        }
+        $child = $path . DIRECTORY_SEPARATOR . $item;
+        if (is_dir($child)) {
+            removeTree($child);
+        } else {
+            unlink($child);
+        }
+    }
+    rmdir($path);
+}
+
+$base = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'review-storage-test-' . uniqid('', true);
+$storagePath = $base . DIRECTORY_SEPARATOR . 'review-batches';
+$batchId = 'test-batch';
+
+try {
+    mkdir($base, 0777, true);
+    $storage = new ReviewBatchStorage(array(
+        'storage' => $base . DIRECTORY_SEPARATOR . 'storage.json',
+        'review' => array('storagePath' => $storagePath),
+    ));
+
+    $batch = array(
+        'id' => $batchId,
+        'source_server' => 'test',
+        'source_tube' => 'tube',
+        'source_state' => 'buried',
+        'review_tube' => 'review.tube',
+        'created_at' => date('c'),
+        'status' => 'complete',
+        'target_count' => 2,
+        'processed' => 2,
+        'errors' => 0,
+    );
+    $storage->createBatch($batch);
+
+    $jobsFile = $storagePath . DIRECTORY_SEPARATOR . $batchId . '.jobs.jsonl';
+    $currentFile = $storagePath . DIRECTORY_SEPARATOR . $batchId . '.current.json';
+    assertTrueValue(is_file($currentFile), 'Current-state file should be created with the batch');
+
+    $storage->appendJob($batchId, array('original_id' => 1, 'review_id' => 101, 'status' => 'moved', 'pri' => 1, 'job_created_at' => '2026-06-19T00:00:00+00:00'));
+    $storage->appendJob($batchId, array('original_id' => 2, 'review_id' => 102, 'status' => 'moved', 'pri' => 2));
+    $storage->updateJob($batchId, array('original_id' => 1, 'review_id' => 101, 'status' => 'returned', 'returned_id' => 201));
+
+    $summary = $storage->getBatchSummary($batchId, 0, 10);
+    assertSameValue(2, $summary['total'], 'Current summary total should match collapsed jobs');
+    assertSameValue(1, $summary['moved_count'], 'Current summary moved count should track latest statuses');
+    assertSameValue(1, $summary['page_selectable_count'], 'Selectable count should use current page moved rows');
+    assertSameValue('returned', $summary['jobs'][0]['status'], 'First job should be returned after update');
+    assertSameValue('2026-06-19T00:00:00+00:00', $summary['jobs'][0]['job_created_at'], 'Original creation time should survive status updates');
+    assertSameValue('moved', $summary['jobs'][1]['status'], 'Second job should remain moved');
+
+    $moved = $storage->getMovedJobs($batchId, 10);
+    assertSameValue(1, count($moved), 'Moved-job lookup should return only current moved rows');
+    assertSameValue(102, (int)$moved[0]['review_id'], 'Moved-job lookup should return the remaining moved review id');
+
+    $selected = $storage->getJobsByReviewIds($batchId, array(101, 102, 999));
+    assertSameValue(2, count($selected), 'Selected lookup should return matching review ids');
+    assertSameValue('returned', $selected[101]['status'], 'Selected lookup should include returned row');
+    assertSameValue('moved', $selected[102]['status'], 'Selected lookup should include moved row');
+
+    $current = json_decode(file_get_contents($currentFile), true);
+    assertSameValue(filesize($jobsFile), (int)$current['audit_size'], 'Current-state audit size should match jobs JSONL size');
+    assertSameValue(2, (int)$current['total'], 'Current-state total should be stored');
+    assertSameValue(1, (int)$current['moved_count'], 'Current-state moved count should be stored');
+
+    file_put_contents($currentFile, json_encode(array(
+        'version' => 1,
+        'audit_size' => 0,
+        'total' => 0,
+        'moved_count' => 0,
+        'jobs' => array(),
+    )));
+    $summary = $storage->getBatchSummary($batchId, 0, 10);
+    assertSameValue(2, $summary['total'], 'Stale current-state file should rebuild from audit JSONL');
+    $current = json_decode(file_get_contents($currentFile), true);
+    assertSameValue(filesize($jobsFile), (int)$current['audit_size'], 'Rebuilt current state should store current audit size');
+
+    file_put_contents($currentFile, '{bad json');
+    $summary = $storage->getBatchSummary($batchId, 0, 10);
+    assertSameValue(2, $summary['total'], 'Malformed current-state file should rebuild from audit JSONL');
+
+    $current = json_decode(file_get_contents($currentFile), true);
+    $current['total'] = 99;
+    $current['audit_size'] = filesize($jobsFile);
+    file_put_contents($currentFile, json_encode($current));
+    $summary = $storage->getBatchSummary($batchId, 0, 10);
+    assertSameValue(2, $summary['total'], 'Current-state count mismatch should rebuild from audit JSONL');
+
+    file_put_contents($currentFile, 'not json');
+    $storage->appendJob($batchId, array('review_id' => 103, 'status' => 'moved', 'pri' => 3));
+    $summary = $storage->getBatchSummary($batchId, 0, 10);
+    assertSameValue(3, $summary['total'], 'Append should recover malformed current state before applying the new row');
+    assertSameValue(2, $summary['moved_count'], 'Append should preserve rebuilt jobs and count the new moved row');
+
+    $storage->appendJob($batchId, array('status' => 'ignored'));
+    $summary = $storage->getBatchSummary($batchId, 0, 10);
+    assertSameValue(3, $summary['total'], 'Rows without a job id should be audited but not added to current jobs');
+    $current = json_decode(file_get_contents($currentFile), true);
+    assertSameValue(filesize($jobsFile), (int)$current['audit_size'], 'Ignored audit rows should still advance current audit size');
+
+    unlink($currentFile);
+    $moved = $storage->getMovedJobs($batchId, 10);
+    assertSameValue(2, count($moved), 'Missing current-state file should rebuild for moved lookup');
+    assertTrueValue(is_file($currentFile), 'Current-state file should be recreated after rebuild');
+
+    $batches = $storage->listBatches();
+    assertSameValue(1, count($batches), 'Batch listing should ignore current-state JSON files');
+
+    $storage->deleteBatch($batchId);
+    assertTrueValue(!is_file($currentFile), 'Batch deletion should remove current-state file');
+    assertTrueValue(!is_file($jobsFile), 'Batch deletion should remove audit file');
+
+    removeTree($base);
+    echo "ReviewBatchStorage current-state tests passed.\n";
+} catch (Exception $e) {
+    removeTree($base);
+    fwrite(STDERR, $e->getMessage() . "\n");
+    exit(1);
+}

--- a/tests/review_batch_storage_current_state_test.php
+++ b/tests/review_batch_storage_current_state_test.php
@@ -60,7 +60,11 @@ try {
 
     $jobsFile = $storagePath . DIRECTORY_SEPARATOR . $batchId . '.jobs.jsonl';
     $currentFile = $storagePath . DIRECTORY_SEPARATOR . $batchId . '.current.json';
+    $bodySnapshotFile = $storagePath . DIRECTORY_SEPARATOR . $batchId . '.body-snapshot.jsonl';
+    $bodySnapshotIndexFile = $storagePath . DIRECTORY_SEPARATOR . $batchId . '.body-snapshot.idx.jsonl';
     assertTrueValue(is_file($currentFile), 'Current-state file should be created with the batch');
+    assertTrueValue(!is_file($bodySnapshotFile), 'Body snapshot file should not be created when snapshots are disabled');
+    assertTrueValue(!is_file($bodySnapshotIndexFile), 'Body snapshot index should not be created when snapshots are disabled');
 
     $storage->appendJob($batchId, array('original_id' => 1, 'review_id' => 101, 'status' => 'moved', 'pri' => 1, 'job_created_at' => '2026-06-19T00:00:00+00:00'));
     $storage->appendJob($batchId, array('original_id' => 2, 'review_id' => 102, 'status' => 'moved', 'pri' => 2));
@@ -83,10 +87,17 @@ try {
     assertSameValue('returned', $selected[101]['status'], 'Selected lookup should include returned row');
     assertSameValue('moved', $selected[102]['status'], 'Selected lookup should include moved row');
 
+    $storage->updateJob($batchId, array('original_id' => 2, 'review_id' => 102, 'status' => 'duplicated', 'target_tube' => 'copy'));
+    $summary = $storage->getBatchSummary($batchId, 0, 10);
+    assertSameValue(0, $summary['moved_count'], 'Duplicated rows should not count as undecided moved jobs');
+    assertSameValue(1, $summary['page_selectable_count'], 'Duplicated rows should remain selectable for further actions');
+    $moved = $storage->getMovedJobs($batchId, 10);
+    assertSameValue(0, count($moved), 'Duplicated rows should not be included in all-undecided bulk operations');
+
     $current = json_decode(file_get_contents($currentFile), true);
     assertSameValue(filesize($jobsFile), (int)$current['audit_size'], 'Current-state audit size should match jobs JSONL size');
     assertSameValue(2, (int)$current['total'], 'Current-state total should be stored');
-    assertSameValue(1, (int)$current['moved_count'], 'Current-state moved count should be stored');
+    assertSameValue(0, (int)$current['moved_count'], 'Current-state moved count should be stored');
 
     file_put_contents($currentFile, json_encode(array(
         'version' => 1,
@@ -115,7 +126,7 @@ try {
     $storage->appendJob($batchId, array('review_id' => 103, 'status' => 'moved', 'pri' => 3));
     $summary = $storage->getBatchSummary($batchId, 0, 10);
     assertSameValue(3, $summary['total'], 'Append should recover malformed current state before applying the new row');
-    assertSameValue(2, $summary['moved_count'], 'Append should preserve rebuilt jobs and count the new moved row');
+    assertSameValue(1, $summary['moved_count'], 'Append should preserve rebuilt jobs and count the new moved row');
 
     $storage->appendJob($batchId, array('status' => 'ignored'));
     $summary = $storage->getBatchSummary($batchId, 0, 10);
@@ -125,7 +136,8 @@ try {
 
     unlink($currentFile);
     $moved = $storage->getMovedJobs($batchId, 10);
-    assertSameValue(2, count($moved), 'Missing current-state file should rebuild for moved lookup');
+    assertSameValue(1, count($moved), 'Missing current-state file should rebuild for moved lookup');
+    assertSameValue(103, (int)$moved[0]['review_id'], 'Moved lookup should include the current moved row');
     assertTrueValue(is_file($currentFile), 'Current-state file should be recreated after rebuild');
 
     $batches = $storage->listBatches();


### PR DESCRIPTION
## Title

Add review batches for safer Beanstalkd job inspection and actions

## Summary

This adds a feature-gated review batch workflow for inspecting a bounded set of jobs from a tube before deciding what to do with them. A review batch copies jobs into an isolated review tube, deletes the original only after the review copy exists, and records an audit/current-state manifest on disk.

The motivation for this was to improve the process of reviewing many buried jobs, where beanstalkd's operational commands are otherwise mostly one-job-at-a-time.

From the review UI, jobs can then be moved back to the source tube, moved elsewhere, duplicated, or deleted.

The feature is disabled by default through config and is intended for operators who currently pause a tube, move jobs aside manually, inspect them, and then move/delete them.

## Main Changes

- Add review batch actions and UI.
- Let the user choose source state (`buried`, `delayed`, `ready`) and count of jobs to review.
- Copy source jobs into a generated review tube.
- Remove original jobs from the source state only after the review copy has been created.
- Check ready/delayed review safety using watcher/waiter counts and tube pause state.
- Offer "Pause tube and proceed" when pausing makes review safe.
- Allow buried review directly because workers cannot reserve buried jobs.
- Use a destination tube field, prefilled with the source tube, for move/duplicate actions.
- Suggest existing tubes in the destination field while still allowing a new tube name.
- Support selected-job and all-undecided-job move, duplicate, and delete operations.
- Keep duplicated review copies actionable until the user moves or deletes them.
- Store append-only JSONL audit logs.
- Store a materialized current-state JSON file for efficient listing, review page, count, and moved-job lookups.
- Optionally store body snapshots with an index sidecar for display/export.
- Add another-session warnings and safe takeover for abandoned review batches.
- Add focused tests for naming, service operations, page data building, and storage current-state behavior.

## Safety Model

The source job is copied into the review tube first. The original source job is deleted only after the review copy is created. If copying succeeds but source deletion fails, the review copy is kept visible with a cleanup/error status so the operator can still inspect and handle it.

Ready and delayed jobs can be reserved by workers, so review prep checks `stats-tube` watcher/waiter counts and pause state. Review can proceed when no clients are watching/waiting, or when the source tube is paused. Buried jobs can proceed directly because buried jobs are not reservable by workers.

## Why This Uses A Review Tube

The review copy remains inside beanstalkd. The JSONL files live on the console server and are used for audit, summaries, body display, and exports. They are not intended to be the only recovery copy of the jobs.

Using a review tube preserves queue-native semantics:

- the review job remains a beanstalkd job
- workers no longer see it in the source tube
- move/duplicate/delete actions operate against a queue-side copy
- partial failures can leave a visible review copy to clean up

## File Overview

- `src/ReviewBatchNaming.php`
  Shared default review tube naming.

- `src/ReviewBatchStorage.php`
  Batch metadata, audit JSONL, current-state cache, body snapshots, operation metadata.

- `src/ReviewBatchService.php`
  Queue operations for preparation, move, duplicate, and delete.

- `src/ReviewBatchPageBuilder.php`
  Review page data assembly, visible body loading, body formatting, missing-copy reconciliation.

- `lib/include.php`
  Action routing, request validation, redirects, JSON responses, feature gate.

- `lib/tpl/reviewBatches.php`
  Review batch listing.

- `lib/tpl/reviewBatchProgress.php`
  Preparation progress page.

- `lib/tpl/reviewBatchShow.php`
  Batch review page.

- `lib/tpl/reviewBatchOperationProgress.php`
  Chunked all-job operation progress page.

- `public/js/customer.js`
  Review modal guard, progress polling, checkbox selection, body toggle/modal.

## Storage Format

Each review batch can have:

- `*.batch.json`: batch metadata such as source server/tube/state, review tube, owner session, progress, and safety message.
- `*.jobs.jsonl`: append-only audit log of prepared jobs and later review actions.
- `*.current.json`: materialized latest state and counts, derived from the audit log for faster listing/review reads.
- `*.body-snapshot.jsonl`: optional captured job bodies from preparation time.
- `*.body-snapshot.idx.jsonl`: optional byte-offset index for targeted body snapshot lookup.
- `*.operation.json`: progress metadata for chunked all-job review operations.

The append-only audit log is the history. The current-state file is derived from it and rebuilt when stale, invalid, missing, or internally inconsistent.

Review batch files are console-local support files used for auditing, current-state tracking, exports, and optional body display. They are not automatically removed over time, but deleting a review batch from the UI removes its batch files.

## Configuration

The feature is disabled by default and can be opted in to by setting `$GLOBALS['config']['review'] = true;` in `config.local.php`:

```php
'review' => array(
    'enabled' => false,
    'chunkSize' => 200,
    'bodyPreviewLength' => 100,
    'allowReadyWhenUnwatched' => true,
    'allowDelayedWhenUnwatched' => true,
    'allowUnsafeReadyOverride' => false,
    'allowUnsafeDelayedOverride' => false,
    'neverIncludeBodySnapshot' => false,
    'storagePath' => null,
),
```

`neverIncludeBodySnapshot` hides the body-snapshot checkbox and prevents body snapshot files from being created for new batches. In that mode the review UI still works, but bodies are loaded from live review-copy jobs and may no longer be available after those review copies are moved/deleted.

## Tests Run

```text
php tests/review_batch_naming_test.php
php tests/review_batch_service_test.php
php tests/review_batch_page_builder_test.php
php tests/review_batch_storage_current_state_test.php
```

These are focused PHP script tests using mocked jobs, mocked queue/client actions, and temporary local storage. They cover naming, review operation behavior, preparation copy/delete ordering, missing or failed queue operations, body snapshot/live-body selection, and current-state rebuild behavior without requiring a running beanstalkd server.

Manual browser testing was also done against a real Beanstalkd server.

## Notes And Tradeoffs

- The feature is intentionally opt-in via config.
- The review batch workflow keeps actionable review copies in Beanstalkd, while console-local files store the batch bookkeeping: audit history, current status, original job metadata, and optional body snapshots. The JSONL files support the review workflow but are not a replacement queue.
- Reviewed jobs receive new beanstalkd job ids when they are copied into the review tube and again when moved or duplicated to a destination tube. The review files keep the original, review, returned, and target ids where relevant so operators can correlate the lifecycle.
- Body snapshots are optional. Enabling them preserves review-time payloads and makes later body display more efficient by reading local snapshot data instead of peeking each review-copy job from the queue, but it can create large local files.
- Review batch files are not automatically removed over time, but deleting a review batch from the UI removes its batch files. Completed batches should be deleted or body snapshots disabled if disk growth is a concern.
