### PR TITLE
Refine review batch navigation and row selection

### DIFF
--- a/lib/tpl/currentTubeJobsActionsRow.php
+++ b/lib/tpl/currentTubeJobsActionsRow.php
@@ -40,6 +40,7 @@ $reviewStateCounts = array(
     'delayed' => $delayedJobsCount,
     'ready' => $readyJobsCount,
 );
+$hasReviewableJobs = array_sum($reviewStateCounts) > 0;
 
 if ($activeBatchToAppend) {
     $bState = $activeBatchToAppend['source_state'];
@@ -119,8 +120,11 @@ if ($tubePauseSeconds === -1) {
 
     <?php if ($reviewEnabled && $matchingReviewBatch): ?>
         <a class="btn btn-info btn-sm" href="./?server=<?php echo urlencode($server); ?>&action=reviewBatchShow&batchId=<?php echo urlencode($matchingReviewBatch['id']); ?>"><i class="glyphicon glyphicon-eye-open glyphicon-white"></i> Go to review batch</a>
-    <?php elseif ($reviewEnabled): ?>
+    <?php elseif ($reviewEnabled && $hasReviewableJobs): ?>
         <a data-toggle="modal" class="btn btn-info btn-sm" href="#reviewBatchStart"><i class="glyphicon glyphicon-eye-open glyphicon-white"></i> Prepare review batch</a>
+    <?php endif; ?>
+    <?php if ($reviewEnabled && !$matchingReviewBatch && $reviewBatchCount > 0): ?>
+        <a class="btn btn-default btn-sm" href="./?server=<?php echo urlencode($server); ?>&action=reviewBatches&sourceTube=<?php echo urlencode($tube); ?>"><i class="glyphicon glyphicon-list-alt"></i> Reviews for this tube (<?php echo (int)$reviewBatchCount; ?>)</a>
     <?php endif; ?>
 
     <!-- DEBUG:

--- a/lib/tpl/reviewBatchShow.php
+++ b/lib/tpl/reviewBatchShow.php
@@ -285,6 +285,7 @@ if (!in_array($batch['source_tube'], $targetTubeOptions, true)) {
                                 <pre class="reviewJobBodyPreview"
                                      data-review-id="<?php echo $reviewId; ?>"
                                      data-preview="<?php echo htmlspecialchars($preview); ?>"
+                                     title="Click to view full body"
                                      style="max-height: 120px; overflow: auto; white-space: pre-wrap; word-break: break-word;"><?php echo htmlspecialchars($preview); ?></pre>
                                 <pre class="reviewJobBodyFull"
                                      data-review-id="<?php echo $reviewId; ?>"

--- a/public/js/customer.js
+++ b/public/js/customer.js
@@ -3,6 +3,7 @@ $(document).ready(
 
             var timer;
             var doAutoRefresh = false;
+            var pendingReviewRowClick = null;
 
             // Helper function to get setting value (Cookie > Default > Fallback)
             function getSettingValue(key, ultimateFallback) {
@@ -270,34 +271,72 @@ $(document).ready(
                     return false;
                 });
                 var lastReviewCheckbox = null;
-                $('.reviewJobCheckbox').on('click', function (e) {
-                    if (e.shiftKey && lastReviewCheckbox) {
+                function selectReviewCheckbox(checkbox, checked, shiftKey) {
+                    checkbox.checked = checked;
+                    if (shiftKey && lastReviewCheckbox) {
                         clearTextSelection();
-                        selectReviewCheckboxRange(lastReviewCheckbox, this, $(this).is(':checked'));
-                    }
-                    lastReviewCheckbox = this;
-                    updateReviewSelectAllState();
-                    e.stopPropagation();
-                });
-                $('.reviewJobCheckbox').on('click', function (e) {
-                    var checkbox = this;
-                    if (e.shiftKey && lastReviewCheckbox) {
-                        selectReviewCheckboxRange(lastReviewCheckbox, checkbox, checkbox.checked);
+                        selectReviewCheckboxRange(lastReviewCheckbox, checkbox, checked);
                     }
                     lastReviewCheckbox = checkbox;
                     updateReviewSelectAllState();
+                }
+                $('.reviewJobCheckbox').on('click', function (e) {
+                    selectReviewCheckbox(this, this.checked, e.shiftKey);
+                    e.stopPropagation();
                 });
                 $('.reviewJobView').on('click', function () {
                     loadReviewJobBody($(this).data('review-id'), this);
                     return false;
                 });
-                $('#reviewJobsTable tbody').on('click', 'tr.clickable-row', function (e) {
+                var reviewRowMouseDown = null;
+                // Track movement so dragging to select text does not also select the review row.
+                $('#reviewJobsTable tbody').on('mousedown', 'tr', function (e) {
+                    reviewRowMouseDown = {
+                        row: this,
+                        x: e.pageX,
+                        y: e.pageY
+                    };
+                });
+                // Body previews open the modal; the rest of the row is reserved for selection.
+                $('#reviewJobsTable tbody').on('click', '.reviewJobBodyPreview', function (e) {
+                    var $btn = $(this).closest('tr').find('.reviewJobView');
+                    if ($btn.length) {
+                        loadReviewJobBody($btn.data('review-id'), $btn[0]);
+                    }
+                    e.stopPropagation();
+                    return false;
+                });
+                // Delay row selection slightly so double-click text selection can cancel it.
+                $('#reviewJobsTable tbody').on('click', 'tr', function (e) {
                     if ($(e.target).is('input, button, a') || $(e.target).parents('input, button, a').length) {
                         return;
                     }
-                    var $btn = $(this).find('.reviewJobView');
-                    if ($btn.length) {
-                        loadReviewJobBody($btn.data('review-id'), $btn[0]);
+                    if (e.detail && e.detail > 1) {
+                        clearPendingReviewRowClick();
+                        return;
+                    }
+                    if (getSelectedText()) {
+                        return;
+                    }
+                    if (reviewRowMouseDown && reviewRowMouseDown.row === this) {
+                        var dx = Math.abs(e.pageX - reviewRowMouseDown.x);
+                        var dy = Math.abs(e.pageY - reviewRowMouseDown.y);
+                        if (dx > 4 || dy > 4) {
+                            return;
+                        }
+                    }
+                    var $checkbox = $(this).find('.reviewJobCheckbox');
+                    if ($checkbox.length) {
+                        var checkbox = $checkbox[0];
+                        var checked = !$checkbox.prop('checked');
+                        var shiftKey = e.shiftKey;
+                        clearPendingReviewRowClick();
+                        pendingReviewRowClick = window.setTimeout(function () {
+                            if (!getSelectedText()) {
+                                selectReviewCheckbox(checkbox, checked, shiftKey);
+                            }
+                            pendingReviewRowClick = null;
+                        }, 160);
                     }
                 });
                 $('#reviewToggleBodies').on('click', function () {
@@ -660,6 +699,14 @@ $(document).ready(
                 $('#reviewSelectAll').prop('checked', $boxes.length > 0 && checkedCount === $boxes.length);
             }
 
+            // Cancel a pending row toggle when the click turns into a double-click.
+            function clearPendingReviewRowClick() {
+                if (pendingReviewRowClick) {
+                    window.clearTimeout(pendingReviewRowClick);
+                    pendingReviewRowClick = null;
+                }
+            }
+
             // Prevent accidental text highlighting while using shift-click range selection.
             function clearTextSelection() {
                 if (window.getSelection) {
@@ -667,6 +714,17 @@ $(document).ready(
                 } else if (document.selection) {
                     document.selection.empty();
                 }
+            }
+
+            // Row clicks should not toggle selection after a text selection gesture.
+            function getSelectedText() {
+                if (window.getSelection) {
+                    return $.trim(window.getSelection().toString());
+                }
+                if (document.selection && document.selection.createRange) {
+                    return $.trim(document.selection.createRange().text);
+                }
+                return '';
             }
 
             function formatDuration(value) {


### PR DESCRIPTION
This follows up on the review batch UI changes.

Summary:
- Restore row-click selection on the review batch table, so clicking a job row checks/unchecks its checkbox.
- Keep body inspection available by opening the modal from the body preview column.
- Avoid accidental row selection while selecting text by ignoring drag selection, double-click text selection, and existing selected text.
- Restore the "Reviews for this tube" navigation button on source tube pages when review batches already exist for that tube.
- Hide unecessary "Prepare review batch" button when the tube has no ready, delayed, or buried jobs to review.
