### PR TITLE
Add per-tube job body display settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 nbproject/
 config.local.php
 review-batches/
+tube-body-display.json

--- a/config.php
+++ b/config.php
@@ -77,6 +77,14 @@ $GLOBALS['config'] = array(
     ),
 
     /**
+     * Per-server, per-tube job body display overrides.
+     */
+    'tubeBodyDisplay' => array(
+        // null means dirname($config['storage']) . '/tube-body-display.json'.
+        'storage' => null,
+    ),
+
+    /**
      * Review batch settings.
      */
     'review' => array(

--- a/lib/BeanstalkInterface.class.php
+++ b/lib/BeanstalkInterface.class.php
@@ -6,14 +6,20 @@ class BeanstalkInterface {
     protected $_tubes;
     public $_client;
     private $settings;
+    private $server;
+    private $bodyDisplaySettings;
+    private $bodyFormatter;
 
     /**
      * Constructor
      *
      * @param string $server The server connection string (e.g., "localhost:11300" or "beanstalk://host:port").
      * @param Settings $settings The Settings object instance.
+     * @param TubeBodyDisplaySettings|null $bodyDisplaySettings Per-tube display resolver.
+     * @param JobBodyFormatter|null $bodyFormatter Body formatter.
      */
-    public function __construct($server, $settings = null) {
+    public function __construct($server, $settings = null, $bodyDisplaySettings = null, $bodyFormatter = null) {
+        $this->server = $server;
         if (strpos($server, "beanstalk://") === 0) {
             $url = parse_url($server);
             $host = $url['host'];
@@ -25,6 +31,8 @@ class BeanstalkInterface {
         }
         $this->_client = new Pheanstalk($host, $port);
         $this->settings = $settings ?? new Settings();
+        $this->bodyDisplaySettings = $bodyDisplaySettings !== null ? $bodyDisplaySettings : new TubeBodyDisplaySettings($this->settings);
+        $this->bodyFormatter = $bodyFormatter !== null ? $bodyFormatter : new JobBodyFormatter();
     }
 
     public function getTubes() {
@@ -232,7 +240,7 @@ class BeanstalkInterface {
             $peek = array();
         }
         if ($peek) {
-            $peek['data'] = $this->_decodeData($peek['data']);
+            $peek['data'] = $this->_decodeData($peek['data'], $tube);
         }
         return $peek;
     }
@@ -241,53 +249,14 @@ class BeanstalkInterface {
      * Decodes job data based on user settings.
      *
      * @param string $pData Raw job data.
+     * @param string $tube Tube name.
      * @return mixed Decoded data or original data if no decoding applied/successful.
      */
-    private function _decodeData($pData) { // Renamed from _decodeDate for clarity
-        $this->_contentType = false; // Reset content type flag
-        $out = $pData; // Default output is the raw data
-        $data = null; // Intermediate decoded data
-
-        // 1. Try Base64 Decode (if enabled in settings)
-        if ($this->settings->isBase64DecodeEnabled()) {
-            set_error_handler(array($this, 'exceptions_error_handler'));
-            try {
-                $data = base64_decode($pData);
-            } catch (Exception $e) {
-                $data = $e->getMessage();
-            }
-            ob_get_clean();
-            // restore old error handler
-            restore_error_handler();
-        }
-
-        // 2. Try Unserialize (if enabled in settings)
-        if ($this->settings->isUnserializationEnabled()) {
-            set_error_handler(array($this, 'exceptions_error_handler'));
-            try {
-                $data = unserialize($pData);
-            } catch (Exception $e) {
-                $data = $e->getMessage();
-            }
-            ob_get_clean();
-            // restore old error handler
-            restore_error_handler();
-        }
-
-        if ($data) {
-            $this->_contentType = 'php';
-            $out = $data;
-        } else {
-            // 3. Try JSON Decode (if enabled in settings)
-            if ($this->settings->isJsonDecodeEnabled()) {
-                $data = @json_decode($pData, true);
-            }
-            if ($data) {
-                $this->_contentType = 'json';
-                //$out = $data;
-            }
-        }
-        return $out;
+    private function _decodeData($pData, $tube) { // Renamed from _decodeDate for clarity
+        $displaySettings = $this->bodyDisplaySettings->getEffectiveSettings($this->server, $tube);
+        $display = $this->bodyFormatter->decodeForPeek($pData, $displaySettings);
+        $this->_contentType = $display['content_type'] === 'text' ? false : $display['content_type'];
+        return $display['body'];
     }
 
     public function exceptions_error_handler($severity, $message, $filename, $lineno) {

--- a/lib/include.php
+++ b/lib/include.php
@@ -26,6 +26,9 @@ require_once dirname(__FILE__) . '/../src/ReviewBatchNaming.php';
 require_once dirname(__FILE__) . '/../src/ReviewBatchStorage.php';
 require_once dirname(__FILE__) . '/../src/ReviewBatchService.php';
 require_once dirname(__FILE__) . '/../src/Settings.php';
+require_once dirname(__FILE__) . '/../src/TubeBodyDisplayStorage.php';
+require_once dirname(__FILE__) . '/../src/TubeBodyDisplaySettings.php';
+require_once dirname(__FILE__) . '/../src/JobBodyFormatter.php';
 require_once dirname(__FILE__) . '/../src/ReviewBatchPageBuilder.php';
 
 $GLOBALS['server'] = !empty($_GET['server']) ? filter_input(INPUT_GET, 'server', FILTER_SANITIZE_SPECIAL_CHARS) : '';
@@ -50,6 +53,8 @@ class Console {
     private $serversCookie = array();
     private $searchResults = array();
     private $reviewBatchPageBuilder = null;
+    private $tubeBodyDisplayStorage = null;
+    private $tubeBodyDisplaySettings = null;
     private $actionTimeStart = 0;
 
     public function __construct() {
@@ -384,7 +389,12 @@ class Console {
         }
 
         try {
-            $this->interface = new BeanstalkInterface($this->_globalVar['server']);
+            $this->interface = new BeanstalkInterface(
+                $this->_globalVar['server'],
+                new Settings(),
+                $this->getTubeBodyDisplaySettings(),
+                new JobBodyFormatter()
+            );
 
             if (!empty($_GET['action']) && $this->shouldDispatchBeforeTubeStats($this->_globalVar['action'])) {
                 if ($this->isReviewJsonAction($this->_globalVar['action'])) {
@@ -407,6 +417,9 @@ class Console {
                 $this->_tplVars['peek'] = $this->interface->peekAll($this->_globalVar['tube']);
             }
             $this->_tplVars['contentType'] = $this->interface->getContentType();
+            if (!empty($this->_globalVar['tube'])) {
+                $this->setTubeBodyDisplayTplVars($this->_globalVar['server'], $this->_globalVar['tube']);
+            }
             // Refactor target: this dispatch block can eventually share dispatchAction().
             if (!empty($_GET['action'])) {
                 $funcName = "_action" . ucfirst($this->_globalVar['action']);
@@ -489,6 +502,7 @@ class Console {
             'reviewBatchTakeOver',
             'reviewBatchOperationStart',
             'reviewBatchOperationProcess',
+            'tubeBodyDisplaySave',
         ), true);
     }
 
@@ -640,6 +654,46 @@ class Console {
         $this->interface->pauseTube($this->_globalVar['tube'], $delay);
         header(
                 sprintf('Location: ./?server=%s&tube=%s', $this->_globalVar['server'], urlencode($this->_globalVar['tube'])));
+        exit();
+    }
+
+    /**
+     * Saves or clears the current tube body display override.
+     *
+     * @return void
+     * @throws InvalidArgumentException If the override cannot be saved.
+     */
+    protected function _actionTubeBodyDisplaySave() {
+        $tube = isset($_POST['tube']) ? $_POST['tube'] : $this->_globalVar['tube'];
+        $targetServer = $this->_globalVar['server'];
+        if ($tube === '') {
+            throw new InvalidArgumentException('Tube is required');
+        }
+
+        $resolver = $this->getTubeBodyDisplaySettings();
+        $mode = isset($_POST['mode']) ? $_POST['mode'] : 'global';
+        if ($mode === 'custom') {
+            $resolver->saveOverride($targetServer, $tube, array(
+                'enableBase64Decode' => !empty($_POST['enableBase64Decode']),
+                'enableUnserialization' => !empty($_POST['enableUnserialization']),
+                'enableJsonDecode' => !empty($_POST['enableJsonDecode']),
+            ));
+        } else {
+            $resolver->deleteOverride($targetServer, $tube);
+        }
+
+        if (!empty($_POST['batchId']) && $this->isReviewEnabled()) {
+            $batch = $this->getReviewBatchStorage()->loadBatch($_POST['batchId']);
+            if ($batch
+                    && isset($batch['source_server'], $batch['source_tube'])
+                    && $batch['source_server'] === $this->_globalVar['server']
+                    && $batch['source_tube'] === $tube) {
+                header('Location: ' . $this->reviewBatchShowUrl($batch['id']));
+                exit();
+            }
+        }
+
+        header(sprintf('Location: ./?server=%s&tube=%s', urlencode($this->_globalVar['server']), urlencode($tube)));
         exit();
     }
 
@@ -935,6 +989,7 @@ class Console {
         $this->_tplVars['_tplPage'] = 'reviewBatchProgress';
         $this->_tplVars['reviewBatch'] = $batch;
         $this->_tplVars['reviewOperation'] = $storage->loadOperation($batch['id']);
+        $this->setTubeBodyDisplayTplVarsForBatch($batch);
     }
 
     /**
@@ -994,8 +1049,14 @@ class Console {
 
         $this->_tplVars['_tplMain'] = 'main';
         $this->_tplVars['_tplPage'] = 'reviewBatchShow';
-        $pageBuilder = new ReviewBatchPageBuilder($this->interface, $storage);
+        $pageBuilder = new ReviewBatchPageBuilder(
+            $this->interface,
+            $storage,
+            $this->getTubeBodyDisplaySettings(),
+            new JobBodyFormatter()
+        );
         $this->_tplVars = array_merge($this->_tplVars, $pageBuilder->buildShowPage($batch, $page, $perPage, $previewLength));
+        $this->setTubeBodyDisplayTplVarsForBatch($batch);
     }
 
     /**
@@ -1220,6 +1281,7 @@ class Console {
         $this->_tplVars['_tplPage'] = 'reviewBatchOperationProgress';
         $this->_tplVars['reviewBatch'] = $batch;
         $this->_tplVars['reviewOperation'] = $operation;
+        $this->setTubeBodyDisplayTplVarsForBatch($batch);
     }
 
     /**
@@ -2034,9 +2096,69 @@ class Console {
      */
     private function getReviewBatchPageBuilder() {
         if ($this->reviewBatchPageBuilder === null) {
-            $this->reviewBatchPageBuilder = new ReviewBatchPageBuilder($this->interface, $this->getReviewBatchStorage());
+            $this->reviewBatchPageBuilder = new ReviewBatchPageBuilder(
+                $this->interface,
+                $this->getReviewBatchStorage(),
+                $this->getTubeBodyDisplaySettings(),
+                new JobBodyFormatter()
+            );
         }
         return $this->reviewBatchPageBuilder;
+    }
+
+    /**
+     * Returns per-tube body display storage.
+     *
+     * @return TubeBodyDisplayStorage
+     */
+    private function getTubeBodyDisplayStorage() {
+        if ($this->tubeBodyDisplayStorage === null) {
+            $this->tubeBodyDisplayStorage = new TubeBodyDisplayStorage($this->_globalVar['config']);
+        }
+        return $this->tubeBodyDisplayStorage;
+    }
+
+    /**
+     * Returns the body display settings resolver.
+     *
+     * @return TubeBodyDisplaySettings
+     */
+    private function getTubeBodyDisplaySettings() {
+        if ($this->tubeBodyDisplaySettings === null) {
+            $this->tubeBodyDisplaySettings = new TubeBodyDisplaySettings(new Settings(), $this->getTubeBodyDisplayStorage());
+        }
+        return $this->tubeBodyDisplaySettings;
+    }
+
+    /**
+     * Sets template variables for editing one tube's body display settings.
+     *
+     * @param string $targetServer Server connection string.
+     * @param string $targetTube Tube name.
+     * @param string $batchId Optional review batch id.
+     * @return void
+     * @throws InvalidArgumentException If tube display settings cannot be read.
+     */
+    private function setTubeBodyDisplayTplVars($targetServer, $targetTube, $batchId = '') {
+        $display = $this->getTubeBodyDisplaySettings()->getEffectiveSettings($targetServer, $targetTube);
+        $this->_tplVars['tubeBodyDisplayTargetServer'] = $targetServer;
+        $this->_tplVars['tubeBodyDisplayTargetTube'] = $targetTube;
+        $this->_tplVars['tubeBodyDisplayBatchId'] = $batchId;
+        $this->_tplVars['tubeBodyDisplay'] = $display;
+        $this->_tplVars['tubeBodyDisplayOverride'] = !empty($display['has_override']) ? $display : null;
+    }
+
+    /**
+     * Sets template variables for editing the source tube body display settings.
+     *
+     * @param array $batch Review batch metadata.
+     * @return void
+     * @throws InvalidArgumentException If tube display settings cannot be read.
+     */
+    private function setTubeBodyDisplayTplVarsForBatch($batch) {
+        $targetServer = isset($batch['source_server']) ? $batch['source_server'] : $this->_globalVar['server'];
+        $targetTube = isset($batch['source_tube']) ? $batch['source_tube'] : '';
+        $this->setTubeBodyDisplayTplVars($targetServer, $targetTube, isset($batch['id']) ? $batch['id'] : '');
     }
 
     /**

--- a/lib/tpl/main.php
+++ b/lib/tpl/main.php
@@ -6,6 +6,14 @@ if ($server) {
 }
 $settings = new Settings();
 $jsDefaults = $settings->getAllDefaults();
+$tubeBodyDisplayTargetTube = null;
+$tubeBodyDisplayMenuLabel = 'Edit settings for this tube';
+if ($server && $tube && isset($tubes) && in_array($tube, $tubes)) {
+    $tubeBodyDisplayTargetTube = $tube;
+} elseif (isset($reviewBatch['source_tube']) && $reviewBatch['source_tube'] !== '') {
+    $tubeBodyDisplayTargetTube = $reviewBatch['source_tube'];
+    $tubeBodyDisplayMenuLabel = 'Edit settings for source tube';
+}
 ?>
 <!DOCTYPE html>
 <html>
@@ -147,7 +155,10 @@ $jsDefaults = $settings->getAllDefaults();
                                     <li><a href="https://github.com/kr/beanstalkd/blob/master/doc/protocol.txt">Protocol Specification</a></li>
                                     <li><a href="https://github.com/ptrofimov/beanstalk_console">Beanstalk console (github)</a></li>
                                     <li class="divider"></li>
-                                    <li><a href="#settings" role="button" data-toggle="modal">Edit settings</a></li>
+                                    <li><a href="#settings" role="button" data-toggle="modal">Edit settings (global)</a></li>
+                                    <?php if ($tubeBodyDisplayTargetTube) { ?>
+                                        <li><a href="#tube-body-display-settings" role="button" data-toggle="modal"><?php echo htmlspecialchars($tubeBodyDisplayMenuLabel); ?></a></li>
+                                    <?php } ?>
                                 </ul>
                             </li>
                             <?php if (@$config['auth']['enabled']) { ?>
@@ -248,6 +259,9 @@ $jsDefaults = $settings->getAllDefaults();
                             <?php require_once dirname(__FILE__) . '/modalFilterColumns.php'; ?>
                         <?php } ?>
                         <?php require_once dirname(__FILE__) . '/modalSettings.php'; ?>
+                        <?php if ($tubeBodyDisplayTargetTube) { ?>
+                            <?php require_once dirname(__FILE__) . '/modalTubeBodyDisplaySettings.php'; ?>
+                        <?php } ?>
                     <?php endif; ?>
             </div>
 

--- a/lib/tpl/modalTubeBodyDisplaySettings.php
+++ b/lib/tpl/modalTubeBodyDisplaySettings.php
@@ -1,0 +1,69 @@
+<?php
+$tubeBodyDisplay = isset($tubeBodyDisplay) && is_array($tubeBodyDisplay) ? $tubeBodyDisplay : array();
+$tubeBodyDisplayOverride = isset($tubeBodyDisplayOverride) && is_array($tubeBodyDisplayOverride) ? $tubeBodyDisplayOverride : null;
+$hasTubeBodyDisplayOverride = $tubeBodyDisplayOverride !== null;
+$bodyDisplayValues = $hasTubeBodyDisplayOverride ? $tubeBodyDisplayOverride : $tubeBodyDisplay;
+$bodyDisplayTargetTube = isset($tubeBodyDisplayTargetTube) && $tubeBodyDisplayTargetTube !== '' ? $tubeBodyDisplayTargetTube : $tube;
+$bodyDisplayBatchId = isset($tubeBodyDisplayBatchId) ? $tubeBodyDisplayBatchId : '';
+?>
+<div id="tube-body-display-settings" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="tube-body-display-settings-label" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <form method="post" action="./?server=<?php echo urlencode($server); ?>&action=tubeBodyDisplaySave">
+                <input type="hidden" name="tube" value="<?php echo htmlspecialchars($bodyDisplayTargetTube); ?>">
+                <?php if ($bodyDisplayBatchId !== ''): ?>
+                    <input type="hidden" name="batchId" value="<?php echo htmlspecialchars($bodyDisplayBatchId); ?>">
+                <?php endif; ?>
+                <div class="modal-header">
+                    <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+                    <h4 class="modal-title" id="tube-body-display-settings-label">Body display for <?php echo htmlspecialchars($bodyDisplayTargetTube); ?></h4>
+                </div>
+                <div class="modal-body">
+                    <p class="help-block">
+                        These settings apply to this tube on this server for everyone using this console.
+                        Review batches prepared from this source tube use the same settings.
+                    </p>
+
+                    <div class="radio">
+                        <label>
+                            <input type="radio" name="mode" value="global" <?php if (!$hasTubeBodyDisplayOverride) echo 'checked="checked"'; ?>>
+                            Use global settings
+                        </label>
+                    </div>
+                    <div class="radio">
+                        <label>
+                            <input type="radio" name="mode" value="custom" <?php if ($hasTubeBodyDisplayOverride) echo 'checked="checked"'; ?>>
+                            Custom for this tube
+                        </label>
+                    </div>
+
+                    <div class="form-group" style="margin-top: 15px;">
+                        <label><b>Apply before display</b></label>
+                        <div class="checkbox">
+                            <label>
+                                <input type="checkbox" name="enableBase64Decode" value="1" <?php if (!empty($bodyDisplayValues['enableBase64Decode'])) echo 'checked="checked"'; ?>>
+                                base64_decode()
+                            </label>
+                        </div>
+                        <div class="checkbox">
+                            <label>
+                                <input type="checkbox" name="enableUnserialization" value="1" <?php if (!empty($bodyDisplayValues['enableUnserialization'])) echo 'checked="checked"'; ?>>
+                                unserialize()
+                            </label>
+                        </div>
+                        <div class="checkbox">
+                            <label>
+                                <input type="checkbox" name="enableJsonDecode" value="1" <?php if (!empty($bodyDisplayValues['enableJsonDecode'])) echo 'checked="checked"'; ?>>
+                                json_decode()
+                            </label>
+                        </div>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button class="btn" data-dismiss="modal" aria-hidden="true" type="button">Close</button>
+                    <button class="btn btn-primary" type="submit">Save</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>

--- a/src/JobBodyFormatter.php
+++ b/src/JobBodyFormatter.php
@@ -1,0 +1,98 @@
+<?php
+
+/**
+ * Applies configured body decoders and formats job bodies for display.
+ */
+class JobBodyFormatter {
+
+    /**
+     * Applies decoders while preserving the legacy peek return shape.
+     *
+     * @param string $body Raw job body.
+     * @param array $settings Body display settings.
+     * @return array Decoded value and content type.
+     */
+    public function decodeForPeek($body, $settings) {
+        $result = $this->applyDecoders($body, $settings, false);
+        return array(
+            'body' => $result['peek_body'],
+            'content_type' => $result['content_type'],
+        );
+    }
+
+    /**
+     * Applies decoders and returns a display string.
+     *
+     * @param string $body Raw job body.
+     * @param array $settings Body display settings.
+     * @param bool $html Whether to HTML-escape the formatted body.
+     * @return array Display body and content type.
+     */
+    public function formatForDisplay($body, $settings, $html) {
+        $result = $this->applyDecoders($body, $settings, true);
+        $display = $result['display_body'];
+
+        if (!is_string($display)) {
+            $display = print_r($display, true);
+        }
+        if (!preg_match('//u', $display)) {
+            $display = base64_encode($display);
+            $result['content_type'] = 'base64';
+        }
+
+        return array(
+            'body' => $html ? htmlspecialchars($display) : $display,
+            'content_type' => $result['content_type'],
+        );
+    }
+
+    /**
+     * Applies enabled decoders in display order.
+     *
+     * Base64 runs first so wrapped serialized or JSON payloads can be decoded next.
+     *
+     * @param string $body Raw job body.
+     * @param array $settings Body display settings.
+     * @param bool $formatJson Whether successful JSON should be pretty-printed.
+     * @return array Decoded values and content type.
+     */
+    private function applyDecoders($body, $settings, $formatJson) {
+        $display = $body;
+        $peek = $body;
+        $contentType = 'text';
+
+        if (!empty($settings['enableBase64Decode'])) {
+            $decoded = base64_decode($display, true);
+            if ($decoded !== false) {
+                $display = $decoded;
+                $peek = $decoded;
+                $contentType = 'base64';
+            }
+        }
+
+        if (!empty($settings['enableUnserialization'])) {
+            $unserialized = @unserialize($display);
+            if ($unserialized !== false || $display === serialize(false)) {
+                $display = print_r($unserialized, true);
+                $peek = $unserialized;
+                $contentType = 'php';
+            }
+        }
+
+        if (!empty($settings['enableJsonDecode'])) {
+            $decodedJson = json_decode($display, true);
+            if (json_last_error() === JSON_ERROR_NONE) {
+                if ($formatJson) {
+                    $display = json_encode($decodedJson, JSON_PRETTY_PRINT);
+                }
+                $contentType = 'json';
+            }
+        }
+
+        return array(
+            'display_body' => $display,
+            'peek_body' => $peek,
+            'content_type' => $contentType,
+        );
+    }
+}

--- a/src/ReviewBatchPageBuilder.php
+++ b/src/ReviewBatchPageBuilder.php
@@ -7,16 +7,22 @@ class ReviewBatchPageBuilder {
 
     private $interface;
     private $storage;
+    private $bodyDisplaySettings;
+    private $bodyFormatter;
 
     /**
      * Stores queue and review storage dependencies.
      *
      * @param BeanstalkInterface $interface Queue interface wrapper.
      * @param ReviewBatchStorage $storage Review batch storage.
+     * @param TubeBodyDisplaySettings|null $bodyDisplaySettings Per-tube display resolver.
+     * @param JobBodyFormatter|null $bodyFormatter Body formatter.
      */
-    public function __construct($interface, $storage) {
+    public function __construct($interface, $storage, $bodyDisplaySettings = null, $bodyFormatter = null) {
         $this->interface = $interface;
         $this->storage = $storage;
+        $this->bodyDisplaySettings = $bodyDisplaySettings ?: new TubeBodyDisplaySettings();
+        $this->bodyFormatter = $bodyFormatter ?: new JobBodyFormatter();
     }
 
     /**
@@ -55,7 +61,7 @@ class ReviewBatchPageBuilder {
                 : array();
         foreach ($previewReviewIds as $reviewId) {
             if (isset($bodySnapshots[$reviewId])) {
-                $display = $this->formatJobBodyForDisplay($bodySnapshots[$reviewId]['body'], false);
+                $display = $this->formatJobBodyForDisplay($bodySnapshots[$reviewId]['body'], false, $batch);
                 $bodies[$reviewId] = array(
                     'body' => $display['body'],
                     'content_type' => $display['content_type'],
@@ -66,7 +72,7 @@ class ReviewBatchPageBuilder {
             }
 
             try {
-                $display = $this->getLiveReviewJobBodyDisplay($reviewId);
+                $display = $this->getLiveReviewJobBodyDisplay($reviewId, $batch);
                 $bodies[$reviewId] = array(
                     'body' => $display['body'],
                     'content_type' => $display['content_type'],
@@ -119,6 +125,10 @@ class ReviewBatchPageBuilder {
             'reviewPageBodyCount' => count($bodies),
             'reviewJobPreviews' => $previews,
             'reviewJobBodies' => $bodies,
+            'reviewBodyDisplay' => $this->bodyDisplaySettings->getEffectiveSettings(
+                isset($batch['source_server']) ? $batch['source_server'] : '',
+                isset($batch['source_tube']) ? $batch['source_tube'] : ''
+            ),
         );
     }
 
@@ -126,15 +136,16 @@ class ReviewBatchPageBuilder {
      * Returns a formatted display body for a live review-copy job.
      *
      * @param int $reviewId Review-copy job id.
+     * @param array $batch Review batch metadata.
      * @return array
      * @throws Exception If the live review-copy job cannot be peeked.
      */
-    public function getLiveReviewJobBodyDisplay($reviewId) {
+    public function getLiveReviewJobBodyDisplay($reviewId, $batch = array()) {
         $job = $this->interface->_client->peek((int)$reviewId);
         if (!$job) {
             throw new Exception('Review job not found');
         }
-        return $this->formatJobBodyForDisplay($job->getData(), false);
+        return $this->formatJobBodyForDisplay($job->getData(), false, $batch);
     }
 
     /**
@@ -209,49 +220,15 @@ class ReviewBatchPageBuilder {
      *
      * @param string $body Raw job body.
      * @param bool $html Whether to HTML-escape the formatted body.
+     * @param array $batch Review batch metadata.
      * @return array
+     * @throws InvalidArgumentException If tube display settings cannot be read.
      */
-    public function formatJobBodyForDisplay($body, $html) {
-        $settings = new Settings();
-        $contentType = 'text';
-        $display = $body;
-
-        if ($settings->isBase64DecodeEnabled()) {
-            $decoded = base64_decode($display, true);
-            if ($decoded !== false) {
-                $display = $decoded;
-                $contentType = 'base64';
-            }
-        }
-
-        if ($settings->isUnserializationEnabled()) {
-            $unserialized = @unserialize($display);
-            if ($unserialized !== false || $display === serialize(false)) {
-                $display = print_r($unserialized, true);
-                $contentType = 'php';
-            }
-        }
-
-        if ($settings->isJsonDecodeEnabled()) {
-            $decodedJson = json_decode($display, true);
-            if (json_last_error() === JSON_ERROR_NONE) {
-                $display = json_encode($decodedJson, JSON_PRETTY_PRINT);
-                $contentType = 'json';
-            }
-        }
-
-        if (!is_string($display)) {
-            $display = print_r($display, true);
-        }
-        if (!preg_match('//u', $display)) {
-            $display = base64_encode($display);
-            $contentType = 'base64';
-        }
-
-        return array(
-            'body' => $html ? htmlspecialchars($display) : $display,
-            'content_type' => $contentType,
-        );
+    public function formatJobBodyForDisplay($body, $html, $batch = array()) {
+        $server = isset($batch['source_server']) ? $batch['source_server'] : '';
+        $tube = isset($batch['source_tube']) ? $batch['source_tube'] : '';
+        $settings = $this->bodyDisplaySettings->getEffectiveSettings($server, $tube);
+        return $this->bodyFormatter->formatForDisplay($body, $settings, $html);
     }
 
     /**

--- a/src/TubeBodyDisplaySettings.php
+++ b/src/TubeBodyDisplaySettings.php
@@ -1,0 +1,131 @@
+<?php
+
+/**
+ * Resolves effective body display settings for a server/tube pair.
+ */
+class TubeBodyDisplaySettings {
+
+    private static $keys = array(
+        'enableBase64Decode',
+        'enableUnserialization',
+        'enableJsonDecode',
+    );
+
+    private $settings;
+    private $storage;
+
+    /**
+     * Stores global settings and optional tube override storage.
+     *
+     * @param Settings|null $settings Global UI settings.
+     * @param TubeBodyDisplayStorage|null $storage Tube override storage.
+     */
+    public function __construct($settings = null, $storage = null) {
+        $this->settings = $settings ?: new Settings();
+        $this->storage = $storage;
+    }
+
+    /**
+     * Returns the effective display settings for a server/tube pair.
+     *
+     * @param string $server Server connection string.
+     * @param string $tube Tube name.
+     * @return array Effective settings plus metadata.
+     * @throws InvalidArgumentException If override storage cannot be read.
+     */
+    public function getEffectiveSettings($server, $tube) {
+        $global = $this->getGlobalSettings();
+        $override = $this->getOverride($server, $tube);
+        if ($override !== null) {
+            return array_merge(
+                $this->normalizeSettings($override, $global),
+                array('source' => 'tube', 'has_override' => true)
+            );
+        }
+
+        return array_merge($global, array('source' => 'global', 'has_override' => false));
+    }
+
+    /**
+     * Returns the configured tube override when present.
+     *
+     * @param string $server Server connection string.
+     * @param string $tube Tube name.
+     * @return array|null
+     * @throws InvalidArgumentException If override storage cannot be read.
+     */
+    public function getOverride($server, $tube) {
+        if (!$this->storage || $server === '' || $tube === '') {
+            return null;
+        }
+        return $this->storage->getOverride($server, $tube);
+    }
+
+    /**
+     * Saves a custom tube override.
+     *
+     * @param string $server Server connection string.
+     * @param string $tube Tube name.
+     * @param array $settings Body display settings.
+     * @return void
+     * @throws InvalidArgumentException If override storage cannot be written.
+     */
+    public function saveOverride($server, $tube, $settings) {
+        $this->storage->saveOverride($server, $tube, $this->normalizeSettings($settings));
+    }
+
+    /**
+     * Removes a custom tube override.
+     *
+     * @param string $server Server connection string.
+     * @param string $tube Tube name.
+     * @return void
+     * @throws InvalidArgumentException If override storage cannot be written.
+     */
+    public function deleteOverride($server, $tube) {
+        $this->storage->deleteOverride($server, $tube);
+    }
+
+    /**
+     * Returns global cookie/config body display settings.
+     *
+     * @return array
+     */
+    public function getGlobalSettings() {
+        return array(
+            'enableBase64Decode' => $this->settings->isBase64DecodeEnabled(),
+            'enableUnserialization' => $this->settings->isUnserializationEnabled(),
+            'enableJsonDecode' => $this->settings->isJsonDecodeEnabled(),
+        );
+    }
+
+    /**
+     * Returns only body display setting keys.
+     *
+     * @return array
+     */
+    public static function getSettingKeys() {
+        return self::$keys;
+    }
+
+    /**
+     * Normalizes boolean settings and applies fallback values when supplied.
+     *
+     * @param array $settings Candidate settings.
+     * @param array $fallback Optional fallback settings.
+     * @return array
+     */
+    public function normalizeSettings($settings, $fallback = array()) {
+        $normalized = array();
+        foreach (self::$keys as $key) {
+            if (isset($settings[$key])) {
+                $normalized[$key] = (bool)$settings[$key];
+            } elseif (isset($fallback[$key])) {
+                $normalized[$key] = (bool)$fallback[$key];
+            } else {
+                $normalized[$key] = false;
+            }
+        }
+        return $normalized;
+    }
+}

--- a/src/TubeBodyDisplayStorage.php
+++ b/src/TubeBodyDisplayStorage.php
@@ -1,0 +1,174 @@
+<?php
+
+/**
+ * Stores per-server, per-tube body display overrides.
+ */
+class TubeBodyDisplayStorage {
+
+    const VERSION = 1;
+
+    private $file;
+
+    /**
+     * Builds storage around the configured path, defaulting beside storage.json.
+     *
+     * @param array $config Application config.
+     */
+    public function __construct($config) {
+        if (isset($config['tubeBodyDisplay']['storage']) && $config['tubeBodyDisplay']['storage'] !== '') {
+            $this->file = $config['tubeBodyDisplay']['storage'];
+        } else {
+            $this->file = dirname($config['storage']) . DIRECTORY_SEPARATOR . 'tube-body-display.json';
+        }
+    }
+
+    /**
+     * Returns the configured storage file path.
+     *
+     * @return string
+     */
+    public function getFile() {
+        return $this->file;
+    }
+
+    /**
+     * Returns an override for a server/tube pair when one exists.
+     *
+     * @param string $server Server connection string.
+     * @param string $tube Tube name.
+     * @return array|null
+     * @throws InvalidArgumentException If the storage file cannot be read.
+     */
+    public function getOverride($server, $tube) {
+        $data = $this->read();
+        if (isset($data['servers'][$server][$tube]) && is_array($data['servers'][$server][$tube])) {
+            return $data['servers'][$server][$tube];
+        }
+        return null;
+    }
+
+    /**
+     * Saves an override for a server/tube pair.
+     *
+     * @param string $server Server connection string.
+     * @param string $tube Tube name.
+     * @param array $settings Body display settings.
+     * @return void
+     * @throws InvalidArgumentException If the storage file cannot be written.
+     */
+    public function saveOverride($server, $tube, $settings) {
+        $data = $this->read();
+        if (!isset($data['servers']) || !is_array($data['servers'])) {
+            $data['servers'] = array();
+        }
+        if (!isset($data['servers'][$server]) || !is_array($data['servers'][$server])) {
+            $data['servers'][$server] = array();
+        }
+        $data['servers'][$server][$tube] = $settings;
+        $this->write($data);
+    }
+
+    /**
+     * Removes an override for a server/tube pair.
+     *
+     * @param string $server Server connection string.
+     * @param string $tube Tube name.
+     * @return void
+     * @throws InvalidArgumentException If the storage file cannot be written.
+     */
+    public function deleteOverride($server, $tube) {
+        $data = $this->read();
+        if (isset($data['servers'][$server][$tube])) {
+            unset($data['servers'][$server][$tube]);
+            if (!count($data['servers'][$server])) {
+                unset($data['servers'][$server]);
+            }
+            $this->write($data);
+        }
+    }
+
+    /**
+     * Reads the storage document.
+     *
+     * @return array
+     * @throws InvalidArgumentException If the storage file cannot be read.
+     */
+    private function read() {
+        if (!is_file($this->file)) {
+            return $this->defaultDocument();
+        }
+        if (!is_readable($this->file)) {
+            throw new InvalidArgumentException('Tube body display settings file is not readable: ' . $this->file);
+        }
+
+        $contents = file_get_contents($this->file);
+        if ($contents === false || trim($contents) === '') {
+            return $this->defaultDocument();
+        }
+
+        $data = json_decode($contents, true);
+        if (!is_array($data)) {
+            throw new InvalidArgumentException('Tube body display settings file is not valid JSON: ' . $this->file);
+        }
+        if (!isset($data['version'])) {
+            $data['version'] = self::VERSION;
+        }
+        if (!isset($data['servers']) || !is_array($data['servers'])) {
+            $data['servers'] = array();
+        }
+
+        return $data;
+    }
+
+    /**
+     * Writes the storage document with an exclusive lock.
+     *
+     * @param array $data Storage document.
+     * @return void
+     * @throws InvalidArgumentException If the storage file cannot be written.
+     */
+    private function write($data) {
+        $dir = dirname($this->file);
+        if (!is_dir($dir) || !is_writable($dir)) {
+            throw new InvalidArgumentException('Tube body display settings directory is not writable: ' . $dir);
+        }
+
+        $handle = fopen($this->file, 'c+');
+        if (!$handle) {
+            throw new InvalidArgumentException('Tube body display settings file could not be opened: ' . $this->file);
+        }
+
+        try {
+            if (!flock($handle, LOCK_EX)) {
+                throw new InvalidArgumentException('Tube body display settings file could not be locked: ' . $this->file);
+            }
+            if (!ftruncate($handle, 0) || !rewind($handle)) {
+                throw new InvalidArgumentException('Tube body display settings file could not be prepared: ' . $this->file);
+            }
+            $encoded = json_encode($data, JSON_PRETTY_PRINT);
+            if ($encoded === false || fwrite($handle, $encoded . "\n") === false) {
+                throw new InvalidArgumentException('Tube body display settings file could not be written: ' . $this->file);
+            }
+            fflush($handle);
+            flock($handle, LOCK_UN);
+        } catch (Exception $e) {
+            flock($handle, LOCK_UN);
+            fclose($handle);
+            throw $e;
+        }
+
+        fclose($handle);
+    }
+
+    /**
+     * Returns an empty storage document.
+     *
+     * @return array
+     */
+    private function defaultDocument() {
+        return array(
+            'version' => self::VERSION,
+            'servers' => array(),
+        );
+    }
+}

--- a/tests/review_batch_page_builder_test.php
+++ b/tests/review_batch_page_builder_test.php
@@ -7,6 +7,8 @@ if (!class_exists('Pheanstalk_Response')) {
 }
 
 require_once dirname(__FILE__) . '/../src/Settings.php';
+require_once dirname(__FILE__) . '/../src/TubeBodyDisplaySettings.php';
+require_once dirname(__FILE__) . '/../src/JobBodyFormatter.php';
 require_once dirname(__FILE__) . '/../src/ReviewBatchPageBuilder.php';
 
 $GLOBALS['config'] = array(

--- a/tests/tube_body_display_test.php
+++ b/tests/tube_body_display_test.php
@@ -1,0 +1,81 @@
+<?php
+
+require_once dirname(__FILE__) . '/../src/Settings.php';
+require_once dirname(__FILE__) . '/../src/TubeBodyDisplayStorage.php';
+require_once dirname(__FILE__) . '/../src/TubeBodyDisplaySettings.php';
+require_once dirname(__FILE__) . '/../src/JobBodyFormatter.php';
+
+$base = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'beanstalk-console-tube-body-display-' . uniqid('', true);
+mkdir($base);
+$file = $base . DIRECTORY_SEPARATOR . 'tube-body-display.json';
+
+$GLOBALS['config'] = array(
+    'storage' => $base . DIRECTORY_SEPARATOR . 'storage.json',
+    'settings' => array(
+        'enableBase64Decode' => false,
+        'enableUnserialization' => false,
+        'enableJsonDecode' => true,
+    ),
+    'tubeBodyDisplay' => array(
+        'storage' => $file,
+    ),
+);
+$_COOKIE = array();
+
+function assertTubeBodySame($expected, $actual, $message) {
+    if ($expected !== $actual) {
+        throw new Exception($message . ' Expected ' . var_export($expected, true) . ', got ' . var_export($actual, true));
+    }
+}
+
+try {
+    $storage = new TubeBodyDisplayStorage($GLOBALS['config']);
+    $resolver = new TubeBodyDisplaySettings(new Settings(), $storage);
+    $formatter = new JobBodyFormatter();
+
+    $global = $resolver->getEffectiveSettings('server-a', 'json-tube');
+    assertTubeBodySame(false, $global['enableBase64Decode'], 'Global base64 default should be used without override');
+    assertTubeBodySame(false, $global['enableUnserialization'], 'Global unserialize default should be used without override');
+    assertTubeBodySame(true, $global['enableJsonDecode'], 'Global JSON default should be used without override');
+    assertTubeBodySame('global', $global['source'], 'Missing override should report global source');
+
+    $resolver->saveOverride('server-a', 'wrapped-tube', array(
+        'enableBase64Decode' => true,
+        'enableUnserialization' => true,
+        'enableJsonDecode' => false,
+    ));
+
+    $override = $resolver->getEffectiveSettings('server-a', 'wrapped-tube');
+    assertTubeBodySame(true, $override['enableBase64Decode'], 'Tube override should enable base64');
+    assertTubeBodySame(true, $override['enableUnserialization'], 'Tube override should enable unserialize');
+    assertTubeBodySame(false, $override['enableJsonDecode'], 'Tube override should disable JSON');
+    assertTubeBodySame('tube', $override['source'], 'Override should report tube source');
+
+    $serialized = serialize(array('cmd' => 'httpCallGeneric'));
+    $display = $formatter->formatForDisplay(base64_encode($serialized), $override, false);
+    assertTubeBodySame('php', $display['content_type'], 'Base64-wrapped serialized bodies should render as PHP');
+    if (strpos($display['body'], 'httpCallGeneric') === false) {
+        throw new Exception('Serialized body display should include decoded value');
+    }
+
+    $resolver->saveOverride('server-a', 'json-wrapped-tube', array(
+        'enableBase64Decode' => true,
+        'enableUnserialization' => false,
+        'enableJsonDecode' => true,
+    ));
+    $jsonOverride = $resolver->getEffectiveSettings('server-a', 'json-wrapped-tube');
+    $jsonDisplay = $formatter->formatForDisplay(base64_encode('{"ok":true}'), $jsonOverride, false);
+    assertTubeBodySame('json', $jsonDisplay['content_type'], 'Base64-wrapped JSON bodies should render as JSON');
+    if (strpos($jsonDisplay['body'], '"ok": true') === false) {
+        throw new Exception('JSON body display should be pretty printed after base64 decode');
+    }
+
+    $resolver->deleteOverride('server-a', 'wrapped-tube');
+    $cleared = $resolver->getEffectiveSettings('server-a', 'wrapped-tube');
+    assertTubeBodySame('global', $cleared['source'], 'Deleted override should fall back to global settings');
+
+    echo "TubeBodyDisplay tests passed.\n";
+} catch (Exception $e) {
+    fwrite(STDERR, $e->getMessage() . "\n");
+    exit(1);
+}


### PR DESCRIPTION
This adds optional per-server/per-tube body display settings for job payloads.

The use case is that different tubes can store bodies in different formats. For example, one tube may contain JSON, another serialized PHP data, and another base64-encoded serialized or JSON data. The existing global display settings still work, but switching them globally is awkward when moving between tubes with different formats.

Summary:
- Add per-server/per-tube overrides for:
  - `base64_decode()`
  - `unserialize()`
  - `json_decode()`

Notes:
- Adds a `tubeBodyDisplay.storage` config option. When unset, the storage path defaults to `tube-body-display.json` beside `storage.json`.
- Adds `JobBodyFormatter` and routes both normal tube peek display and review batch body display through it, so body formatting behavior does not diverge between review and non-review pages.
- Adds `TubeBodyDisplaySettings` and `TubeBodyDisplayStorage` to separate resolving effective settings from reading/writing local override state.
- Review batches resolve display settings from their `source_server` and `source_tube`, so the temporary review tube does not need separate configuration.
- The local override file is created only when saving the first override and is ignored by git.
- Selecting “Use global settings” removes the tube override.
- The override key is server + tube, so same-name tubes on different servers can have different display settings.